### PR TITLE
Add preview output in Yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,14 @@
                "default": null,
                "description": "External strings to pass to `jsonnet` executable.",
                "type": "object"
+            },
+            "jsonnet.outputStyle": {
+               "default": "json",
+               "description": "Preview output mode (yaml / json)",
+               "enum": [
+                  "json",
+                  "yaml"
+               ]
             }
          },
          "title": "Jsonnet configuration",
@@ -62,6 +70,9 @@
             "id": "jsonnet"
          }
       ]
+   },
+   "dependencies": {
+      "js-yaml": "^3.0.0"
    },
    "description": "Language support for Jsonnet",
    "devDependencies": {

--- a/package.jsonnet
+++ b/package.jsonnet
@@ -53,8 +53,9 @@ package.contributes.DefaultConfiguration(
   contributes.configuration.DefaultStringProperty(
     "jsonnet.executablePath", "Location of the `jsonnet` executable.") +
   contributes.configuration.DefaultObjectProperty(
-    "jsonnet.extStrs", "External strings to pass to `jsonnet` executable.")) +
-
+    "jsonnet.extStrs", "External strings to pass to `jsonnet` executable.") +
+  contributes.configuration.DefaultEnumProperty(
+    "jsonnet.outputStyle", "Preview output mode (yaml / json)", ["json", "yaml"], "json")) +
 // Everything else.
 {
   scripts: {
@@ -62,6 +63,9 @@ package.contributes.DefaultConfiguration(
     compile: "tsc -watch -p ./",
     postinstall: "node ./node_modules/vscode/bin/install",
     test: "node ./node_modules/vscode/bin/test"
+  },
+  dependencies: {
+    "js-yaml": "^3.0.0"
   },
   devDependencies: {
     typescript: "^2.0.3",

--- a/package.libsonnet
+++ b/package.libsonnet
@@ -86,6 +86,15 @@
           description: description,
         },
       },
+
+      DefaultEnumProperty(property, description, enum=[], default=null):: {
+       [property]: {
+         default: default,
+         enum: enum,
+         description: description,
+       },
+      },
+
     },
 
     command:: {


### PR DESCRIPTION
Added a setting to select renderer format: `json` or `yaml`. 
It parses the json output of jsonnet and dump it as yaml


note: Sorry, I used auto-format, couple code-style changes got included in the commit

fixes #3 