### PR TITLE
Implement significant parts of `Analyzer`

### DIFF
--- a/server/ast/analyzer.ts
+++ b/server/ast/analyzer.ts
@@ -285,10 +285,10 @@ export class Analyzer implements EventedAnalyzer {
   public resolveIndex = (index: ast.Index): ast.Node | null => {
     if (index.target == null) {
       throw new Error(
-        `INTERNAL ERROR: Index node must have a target:\n${index}`);
+        `INTERNAL ERROR: Index node must have a target:\n${ast.renderAsJson(index)}`);
     } else if (index.id == null) {
       throw new Error(
-        `INTERNAL ERROR: Index node must have a name:\n${index}`);
+        `INTERNAL ERROR: Index node must have a name:\n${ast.renderAsJson(index)}`);
     }
 
     // Find root target, look up in environment.
@@ -323,7 +323,7 @@ export class Analyzer implements EventedAnalyzer {
       }
       default: {
         throw new Error(
-          `INTERNAL ERROR: Index node can't have node target of type '${index.target.type}':\n${index.target}`);
+          `INTERNAL ERROR: Index node can't have node target of type '${index.target.type}':\n${ast.renderAsJson(index.target)}`);
       }
     }
 
@@ -348,7 +348,7 @@ export class Analyzer implements EventedAnalyzer {
       }
       default: {
         throw new Error(
-          `INTERNAL ERROR: Index node currently requires resolved var to be an object type, but was'${resolvedTarget.type}':\n${resolvedTarget}`);
+          `INTERNAL ERROR: Index node currently requires resolved var to be an object type, but was'${resolvedTarget.type}':\n${ast.renderAsJson(resolvedTarget)}`);
       }
     }
   }
@@ -397,7 +397,7 @@ export class Analyzer implements EventedAnalyzer {
       }
       default: {
         throw new Error(
-          `INTERNAL ERROR: Bind currently requires an import node as body ${bind}`);
+          `INTERNAL ERROR: Bind currently requires an import or object node as body ${ast.renderAsJson(bind.body)}`);
       }
     }
   }

--- a/server/ast/analyzer.ts
+++ b/server/ast/analyzer.ts
@@ -391,6 +391,10 @@ export class Analyzer implements EventedAnalyzer {
       return null;
     }
 
+    if (node.parent && ast.isObjectField(node.parent)) {
+      return node.parent;
+    }
+
     switch(node.type) {
       case "IdentifierNode": {
         return this.resolveIdentifier(<ast.Identifier>node);

--- a/server/ast/analyzer.ts
+++ b/server/ast/analyzer.ts
@@ -540,21 +540,23 @@ export class Analyzer implements EventedAnalyzer {
 
         return cached.parse;
       }
-      case "ObjectNode": {
-        return bind.body;
+      case "VarNode": {
+        return this.resolveVar(<ast.Var>bind.body);
+      }
+      case "IndexNode": {
+        return this.resolveIndex(<ast.Index>bind.body);
       }
       case "BinaryNode": {
         const binaryNode = <ast.Binary>bind.body;
         if (binaryNode.op !== "BopPlus") {
           throw new Error(
-            `INTERNAL ERROR: Bind currently requires an import or object node as body ${ast.renderAsJson(bind.body)}`);
+            `INTERNAL ERROR: Bind currently can't resolve to binary operations that are not '+':\n${ast.renderAsJson(bind.body)}`);
         }
 
         return binaryNode;
       }
       default: {
-        throw new Error(
-          `INTERNAL ERROR: Bind currently requires an import or object node as body ${ast.renderAsJson(bind.body)}`);
+        return bind.body;
       }
     }
   }

--- a/server/ast/analyzer.ts
+++ b/server/ast/analyzer.ts
@@ -288,7 +288,7 @@ export class Analyzer implements EventedAnalyzer {
     }
 
     // Find root target, look up in environment.
-    let resolvedVar: ast.Node;
+    let resolvedTarget: ast.Node;
     switch (index.target.type) {
       case "VarNode": {
         const nullableResolved = this.resolveVar(<ast.Var>index.target);
@@ -296,7 +296,16 @@ export class Analyzer implements EventedAnalyzer {
           return null;
         }
 
-        resolvedVar = nullableResolved;
+        resolvedTarget = nullableResolved;
+        break;
+      }
+      case "IndexNode": {
+        const nullableResolved = this.resolveIndex(<ast.Index>index.target);
+        if (nullableResolved == null) {
+          return null;
+        }
+
+        resolvedTarget = nullableResolved;
         break;
       }
       default: {
@@ -305,9 +314,9 @@ export class Analyzer implements EventedAnalyzer {
       }
     }
 
-    switch (resolvedVar.type) {
+    switch (resolvedTarget.type) {
       case "ObjectNode": {
-        const objectNode = <ast.ObjectNode>resolvedVar;
+        const objectNode = <ast.ObjectNode>resolvedTarget;
         for (let field of objectNode.fields.toArray()) {
           // We're looking for either a field with the id
           if (field.id != null && field.id.name == index.id.name) {
@@ -326,7 +335,7 @@ export class Analyzer implements EventedAnalyzer {
       }
       default: {
         throw new Error(
-          `INTERNAL ERROR: Index node currently requires resolved var to be an object type, but was'${resolvedVar.type}':\n${resolvedVar}`);
+          `INTERNAL ERROR: Index node currently requires resolved var to be an object type, but was'${resolvedTarget.type}':\n${resolvedTarget}`);
       }
     }
   }

--- a/server/ast/analyzer.ts
+++ b/server/ast/analyzer.ts
@@ -250,9 +250,11 @@ export class Analyzer implements EventedAnalyzer {
 
   public resolveIndex = (index: ast.Index): ast.Node | null => {
     if (index.target == null) {
-      throw new Error(`Index node must have a target:\n${index}`);
+      throw new Error(
+        `INTERNAL ERROR: Index node must have a target:\n${index}`);
     } else if (index.id == null) {
-      throw new Error(`Index node must have a name:\n${index}`);
+      throw new Error(
+        `INTERNAL ERROR: Index node must have a name:\n${index}`);
     }
 
     // Find root target, look up in environment.
@@ -268,7 +270,8 @@ export class Analyzer implements EventedAnalyzer {
         break;
       }
       default: {
-        throw new Error(`Index node can't have node target of type '${index.target.type}':\n${index.target}`);
+        throw new Error(
+          `INTERNAL ERROR: Index node can't have node target of type '${index.target.type}':\n${index.target}`);
       }
     }
 
@@ -285,13 +288,15 @@ export class Analyzer implements EventedAnalyzer {
             continue;
           }
 
-          throw new Error(`Object field is identified by string, but we don't support that yet`);
+          throw new Error(
+            `INTERNAL ERROR: Object field is identified by string, but we don't support that yet`);
         }
 
         return null;
       }
       default: {
-        throw new Error(`Index node currently requires resolved var to be an object type, but was'${resolvedVar.type}':\n${resolvedVar}`);
+        throw new Error(
+          `INTERNAL ERROR: Index node currently requires resolved var to be an object type, but was'${resolvedVar.type}':\n${resolvedVar}`);
       }
     }
   }
@@ -299,7 +304,8 @@ export class Analyzer implements EventedAnalyzer {
   public resolveVar = (varNode: ast.Var): ast.Node | null => {
     // Look up in the environment, get docs for that definition.
     if (varNode.env == null) {
-      throw new Error(`AST improperly set up, property 'env' can't be null:\n${ast.renderAsJson(varNode)}`);
+      throw new Error(
+        `INTERNAL ERROR: AST improperly set up, property 'env' can't be null:\n${ast.renderAsJson(varNode)}`);
     } else if (!varNode.env.has(varNode.id.name)) {
       return null;
     }
@@ -316,7 +322,7 @@ export class Analyzer implements EventedAnalyzer {
     }
 
     if (bind.body == null) {
-      throw new Error(`Bind can't have null body:\n${bind}`);
+      throw new Error(`INTERNAL ERROR: Bind can't have null body:\n${bind}`);
     }
 
     switch(bind.body.type) {
@@ -333,7 +339,7 @@ export class Analyzer implements EventedAnalyzer {
       }
       default: {
         throw new Error(
-          `Bind currently requires an import node as body ${bind}`);
+          `INTERNAL ERROR: Bind currently requires an import node as body ${bind}`);
       }
     }
   }

--- a/server/ast/compiler.ts
+++ b/server/ast/compiler.ts
@@ -10,34 +10,72 @@ import * as error from '../lexer/static_error';
 import * as parser from '../parser/parser';
 import * as lexer from '../lexer/lexer';
 
-export interface PartialParsedDocument {
-  text: string
-  lex: immutable.List<lexer.Token>
-  version?: number
+// ParsedDocument represents a successfully-parsed document.
+export class ParsedDocument {
+  constructor(
+    readonly text: string,
+    readonly lex: lexer.Tokens,
+    readonly parse: ast.Node,
+    readonly version?: number,
+  ) {}
 }
 
-export interface FullParsedDocument {
-  text: string
-  lex: immutable.List<lexer.Token>
-  parse: ast.Node
-  version?: number
-};
+export const isParsedDocument = (testMe: any): testMe is ParsedDocument => {
+    return testMe instanceof ParsedDocument;
+}
 
+// FailedParsedDocument represents a document that failed to parse.
+export class FailedParsedDocument {
+  constructor(
+    readonly text: string,
+    readonly parse: LexFailure | ParseFailure,
+    readonly version?: number,
+  ) {}
+}
+
+export const isFailedParsedDocument = (
+  testMe: any
+): testMe is FailedParsedDocument => {
+    return testMe instanceof FailedParsedDocument;
+}
+
+// LexFailure represents a failure to lex a document.
+export class LexFailure {
+  constructor(
+    readonly lex: lexer.Tokens,
+    readonly lexError: error.StaticError,
+  ) {}
+}
+
+export const isLexFailure = (testMe: any): testMe is LexFailure => {
+    return testMe instanceof LexFailure;
+}
+
+// ParseFailure represents a failure to parse a document.
+export class ParseFailure {
+  constructor(
+    readonly lex: lexer.Tokens,
+    // TODO: Enable this.
+    // readonly parse: ast.Node,
+    readonly parseError: error.StaticError,
+  ) {}
+}
+
+export const isParseFailure = (testMe: any): testMe is ParseFailure => {
+    return testMe instanceof ParseFailure;
+}
+
+// CompilerService represents the core service for parsing and caching
+// parses of documents.
 export interface CompilerService {
   // TODO: Make sure we're actually propagating the correct version to
   // the cache from `TextDocuments`.
   //
-  // TODO: We probably want to deprecate `parseUntil` when we properly
-  // implement the `Hole` node type in the AST.
-  //
   // TODO: Fix `cache` to only take the fileUri.
   cache: (
     fileUri: string, text: string, version?: number
-  ) => FullParsedDocument | null
-  parseUntil: (
-    fileUri: string, text: string, cursor: error.Location, version?: number
-  ) => PartialParsedDocument | null
-  getLastSuccess: (fileUri: string) => FullParsedDocument | null
+  ) => ParsedDocument | FailedParsedDocument
+  getLastSuccess: (fileUri: string) => ParsedDocument | null
   delete: (fileUri: string) => void
 }
 

--- a/server/ast/visitor.ts
+++ b/server/ast/visitor.ts
@@ -20,7 +20,7 @@ export interface Visitor {
   VisitBuiltin(node: ast.Builtin): void
   VisitConditional(node: ast.Conditional): void
   VisitDollar(node: ast.Dollar): void
-  VisitError(node: ast.Error): void
+  VisitError(node: ast.ErrorNode): void
   VisitFunction(node: ast.Function): void
   VisitIdentifier(node: ast.Identifier): void
   VisitImport(node: ast.Import): void
@@ -71,7 +71,7 @@ export abstract class VisitorBase implements Visitor {
         const castedNode = <ast.Apply>node;
         this.VisitApply(castedNode);
         this.Visit(castedNode.target, castedNode, currEnv);
-        castedNode.arguments.forEach((arg: ast.Node) => {
+        castedNode.args.forEach((arg: ast.Node) => {
           this.Visit(arg, castedNode, currEnv);
         });
         return;
@@ -145,7 +145,7 @@ export abstract class VisitorBase implements Visitor {
         return;
       }
       case "ErrorNode": {
-        const castedNode = <ast.Error>node;
+        const castedNode = <ast.ErrorNode>node;
         this.VisitError(castedNode);
         this.Visit(castedNode.expr, castedNode, currEnv);
         return;
@@ -361,7 +361,7 @@ export abstract class VisitorBase implements Visitor {
   public abstract VisitBuiltin = (node: ast.Builtin): void => {}
   public abstract VisitConditional = (node: ast.Conditional): void => {}
   public abstract VisitDollar = (node: ast.Dollar): void => {}
-  public abstract VisitError = (node: ast.Error): void => {}
+  public abstract VisitError = (node: ast.ErrorNode): void => {}
   public abstract VisitFunction = (node: ast.Function): void => {}
 
   public abstract VisitIdentifier = (node: ast.Identifier): void => {}
@@ -401,7 +401,7 @@ export class DeserializingVisitor extends VisitorBase {
   public VisitBuiltin = (node: ast.Builtin): void => {}
   public VisitConditional = (node: ast.Conditional): void => {}
   public VisitDollar = (node: ast.Dollar): void => {}
-  public VisitError = (node: ast.Error): void => {}
+  public VisitError = (node: ast.ErrorNode): void => {}
   public VisitFunction = (node: ast.Function): void => {}
 
   public VisitIdentifier = (node: ast.Identifier): void => {}
@@ -448,7 +448,7 @@ export class CursorVisitor extends VisitorBase {
   public VisitBuiltin = (node: ast.Builtin): void => { this.updateIfCursorInRange(node); }
   public VisitConditional = (node: ast.Conditional): void => { this.updateIfCursorInRange(node); }
   public VisitDollar = (node: ast.Dollar): void => { this.updateIfCursorInRange(node); }
-  public VisitError = (node: ast.Error): void => { this.updateIfCursorInRange(node); }
+  public VisitError = (node: ast.ErrorNode): void => { this.updateIfCursorInRange(node); }
   public VisitFunction = (node: ast.Function): void => { this.updateIfCursorInRange(node); }
 
   public VisitIdentifier = (node: ast.Identifier): void => { this.updateIfCursorInRange(node); }

--- a/server/ast/visitor.ts
+++ b/server/ast/visitor.ts
@@ -71,9 +71,18 @@ export abstract class VisitorBase implements Visitor {
       // case "DollarNode": return this.VisitDollar(node);
       // case "ErrorNode": return this.VisitError(node);
       // case "FunctionNode": return this.VisitFunction(node);
-      case "IdentifierNode": { this.VisitIdentifier(<ast.Identifier>node); }
-      case "ImportNode": { this.VisitImport(<ast.Import>node); }
-      case "ImportStrNode": { this.VisitImportStr(<ast.ImportStr>node); }
+      case "IdentifierNode": {
+        this.VisitIdentifier(<ast.Identifier>node);
+        return;
+      }
+      case "ImportNode": {
+        this.VisitImport(<ast.Import>node);
+        return;
+      }
+      case "ImportStrNode": {
+        this.VisitImportStr(<ast.ImportStr>node);
+        return;
+      }
       case "IndexNode": {
         const castedNode = <ast.Index>node;
         this.VisitIndex(castedNode);

--- a/server/ast/visitor.ts
+++ b/server/ast/visitor.ts
@@ -159,7 +159,18 @@ export abstract class VisitorBase implements Visitor {
         castedNode.parameters.forEach((param: ast.FunctionParam) => {
           this.Visit(param, castedNode, currEnv);
         });
-        this.Visit(castedNode.body, castedNode, currEnv);
+
+        // Add params to environment before visiting body.
+        const envWithParams = castedNode.parameters
+          .reduce(
+            (acc: ast.Environment, field: ast.FunctionParam) => {
+              return acc.merge(ast.environmentFromLocal(field));
+            },
+            immutable.Map<string, ast.LocalBind | ast.FunctionParam>()
+          );
+
+        // Visit body.
+        this.Visit(castedNode.body, castedNode, envWithParams);
         castedNode.trailingComment.forEach((comment: ast.Comment) => {
           this.Visit(comment, castedNode, currEnv);
         });

--- a/server/ast/visitor.ts
+++ b/server/ast/visitor.ts
@@ -240,13 +240,28 @@ export abstract class VisitorBase implements Visitor {
       case "ObjectFieldNode": {
         const castedNode = <ast.ObjectField>node;
         this.VisitObjectField(castedNode);
-        castedNode.id != null && this.Visit(castedNode.id, castedNode, currEnv);
+
+        let newEnv = currEnv;
+        if (castedNode.methodSugar) {
+          // Add params to environment before visiting body.
+          newEnv = newEnv.merge(
+            castedNode.ids
+              .reduce(
+                (acc: ast.Environment, field: ast.FunctionParam) => {
+                  return acc.merge(ast.environmentFromLocal(field));
+                },
+                immutable.Map<string, ast.LocalBind | ast.FunctionParam>()
+              )
+          );
+        }
+
+        castedNode.id != null && this.Visit(castedNode.id, castedNode, newEnv);
         castedNode.expr1 != null && this.Visit(
-          castedNode.expr1, castedNode, currEnv);
+          castedNode.expr1, castedNode, newEnv);
         castedNode.expr2 != null && this.Visit(
-          castedNode.expr2, castedNode, currEnv);
+          castedNode.expr2, castedNode, newEnv);
         castedNode.expr3 != null && this.Visit(
-          castedNode.expr3, castedNode, currEnv);
+          castedNode.expr3, castedNode, newEnv);
         castedNode.headingComments != null &&
           castedNode.headingComments.forEach(comment => {
             if (comment == undefined) {

--- a/server/ast/visitor.ts
+++ b/server/ast/visitor.ts
@@ -9,37 +9,38 @@ import * as lexer from '../lexer/lexer';
 export interface Visitor {
   Visit(node: ast.Node, parent: ast.Node | null, currEnv: ast.Environment): void
   VisitComment(node: ast.Comment): void
-  // VisitCompSpec(node: ast.CompSpec): void
-  // VisitApply(node: ast.Apply): void
-  // VisitApplyBrace(node: ast.ApplyBrace): void
-  // VisitArray(node: ast.Array): void
-  // VisitArrayComp(node: ast.ArrayComp): void
-  // VisitAssert(node: ast.Assert): void
-  // VisitBinary(node: ast.Binary): void
-  // VisitBuiltin(node: ast.Builtin): void
-  // VisitConditional(node: ast.Conditional): void
-  // VisitDollar(node: ast.Dollar): void
-  // VisitError(node: ast.Error): void
-  // VisitFunction(node: ast.Function): void
+  VisitCompSpec(node: ast.CompSpec): void
+  VisitApply(node: ast.Apply): void
+  VisitApplyBrace(node: ast.ApplyBrace): void
+  VisitApplyParamAssignmentNode(node: ast.ApplyParamAssignment): void
+  VisitArray(node: ast.Array): void
+  VisitArrayComp(node: ast.ArrayComp): void
+  VisitAssert(node: ast.Assert): void
+  VisitBinary(node: ast.Binary): void
+  VisitBuiltin(node: ast.Builtin): void
+  VisitConditional(node: ast.Conditional): void
+  VisitDollar(node: ast.Dollar): void
+  VisitError(node: ast.Error): void
+  VisitFunction(node: ast.Function): void
   VisitIdentifier(node: ast.Identifier): void
   VisitImport(node: ast.Import): void
   VisitImportStr(node: ast.ImportStr): void
   VisitIndex(node: ast.Index): void
   // // VisitLocalBind(node: ast.LocalBind): void
   VisitLocal(node: ast.Local): void
-  // VisitLiteralBoolean(node: ast.LiteralBoolean): void
-  // VisitLiteralNull(node: ast.LiteralNull): void
+  VisitLiteralBoolean(node: ast.LiteralBoolean): void
+  VisitLiteralNull(node: ast.LiteralNull): void
   VisitLiteralNumber(node: ast.LiteralNumber): void
-  // VisitLiteralString(node: ast.LiteralString): void
+  VisitLiteralString(node: ast.LiteralString): void
   VisitObjectField(node: ast.ObjectField): void
   VisitObject(node: ast.ObjectNode): void
-  // VisitDesugaredObjectField(node: ast.DesugaredObjectField): void
-  // VisitDesugaredObject(node: ast.DesugaredObject): void
-  // VisitObjectComp(node: ast.ObjectComp): void
-  // VisitObjectComprehensionSimple(node: ast.ObjectComprehensionSimple): void
-  // VisitSelf(node: ast.Self): void
-  // VisitSuperIndex(node: ast.SuperIndex): void
-  // VisitUnary(node: ast.Unary): void
+  VisitDesugaredObjectField(node: ast.DesugaredObjectField): void
+  VisitDesugaredObject(node: ast.DesugaredObject): void
+  VisitObjectComp(node: ast.ObjectComp): void
+  VisitObjectComprehensionSimple(node: ast.ObjectComprehensionSimple): void
+  VisitSelf(node: ast.Self): void
+  VisitSuperIndex(node: ast.SuperIndex): void
+  VisitUnary(node: ast.Unary): void
   VisitVar(node: ast.Var): void
 }
 
@@ -59,18 +60,117 @@ export abstract class VisitorBase implements Visitor {
         this.VisitComment(<ast.Comment>node);
         return;
       }
-      // case "CompSpecNode": return this.VisitCompSpec(node);
-      // case "ApplyNode": return this.VisitApply(node);
-      // case "ApplyBraceNode": return this.VisitApplyBrace(node);
-      // case "ArrayNode": return this.VisitArray(node);
-      // case "ArrayCompNode": return this.VisitArrayComp(node);
-      // case "AssertNode": return this.VisitAssert(node);
-      // case "BinaryNode": return this.VisitBinary(node);
-      // case "BuiltinNode": return this.VisitBuiltin(node);
-      // case "ConditionalNode": return this.VisitConditional(node);
-      // case "DollarNode": return this.VisitDollar(node);
-      // case "ErrorNode": return this.VisitError(node);
-      // case "FunctionNode": return this.VisitFunction(node);
+      case "CompSpecNode": {
+        const castedNode = <ast.CompSpec>node;
+        this.VisitCompSpec(castedNode);
+        castedNode.varName && this.Visit(castedNode.varName, castedNode, currEnv);
+        this.Visit(castedNode.expr, castedNode, currEnv);
+        return;
+      }
+      case "ApplyNode": {
+        const castedNode = <ast.Apply>node;
+        this.VisitApply(castedNode);
+        this.Visit(castedNode.target, castedNode, currEnv);
+        castedNode.arguments.forEach((arg: ast.Node) => {
+          this.Visit(arg, castedNode, currEnv);
+        });
+        return;
+      }
+      case "ApplyBraceNode": {
+        const castedNode = <ast.ApplyBrace>node;
+        this.VisitApplyBrace(castedNode);
+        this.Visit(castedNode.left, castedNode, currEnv);
+        this.Visit(castedNode.right, castedNode, currEnv);
+        return;
+      }
+      case "ApplyParamAssignmentNode": {
+        const castedNode = <ast.ApplyParamAssignment>node;
+        this.VisitApplyParamAssignmentNode(castedNode);
+        this.Visit(castedNode.right, castedNode, currEnv);
+        return;
+      }
+      case "ArrayNode": {
+        const castedNode = <ast.Array>node;
+        this.VisitArray(castedNode);
+        castedNode.headingComment && this.Visit(
+          castedNode.headingComment, castedNode, currEnv);
+        castedNode.elements.forEach((e: ast.Node) => {
+          this.Visit(e, castedNode, currEnv);
+        });
+        castedNode.trailingComment && this.Visit(
+          castedNode.trailingComment, castedNode, currEnv);
+        return;
+      }
+      case "ArrayCompNode": {
+        const castedNode = <ast.ArrayComp>node;
+        this.VisitArrayComp(castedNode);
+        this.Visit(castedNode.body, castedNode, currEnv);
+        castedNode.specs.forEach((spec: ast.CompSpec) =>
+          this.Visit(spec, castedNode, currEnv));
+        return;
+      }
+      case "AssertNode": {
+        const castedNode = <ast.Assert>node;
+        this.VisitAssert(castedNode);
+        this.Visit(castedNode.cond, castedNode, currEnv);
+        castedNode.message && this.Visit(
+          castedNode.message, castedNode, currEnv);
+        this.Visit(castedNode.rest, castedNode, currEnv);
+        return;
+      }
+      case "BinaryNode": {
+        const castedNode = <ast.Binary>node;
+        this.VisitBinary(castedNode);
+        this.Visit(castedNode.left, castedNode, currEnv);
+        this.Visit(castedNode.right, castedNode, currEnv);
+        return;
+      }
+      case "BuiltinNode": {
+        const castedNode = <ast.Builtin>node;
+        this.VisitBuiltin(castedNode);
+        return;
+      }
+      case "ConditionalNode": {
+        const castedNode = <ast.Conditional>node;
+        this.VisitConditional(castedNode);
+        this.Visit(castedNode.cond, castedNode, currEnv);
+        this.Visit(castedNode.branchTrue, castedNode, currEnv);
+        castedNode.branchFalse && this.Visit(
+          castedNode.branchFalse, castedNode, currEnv);
+        return;
+      }
+      case "DollarNode": {
+        const castedNode = <ast.Dollar>node;
+        this.VisitDollar(castedNode);
+        return;
+      }
+      case "ErrorNode": {
+        const castedNode = <ast.Error>node;
+        this.VisitError(castedNode);
+        this.Visit(castedNode.expr, castedNode, currEnv);
+        return;
+      }
+      case "FunctionNode": {
+        const castedNode = <ast.Function>node;
+        this.VisitFunction(castedNode);
+        castedNode.headingComment.forEach((comment: ast.Comment) => {
+          this.Visit(comment, castedNode, currEnv);
+        });
+        castedNode.parameters.forEach((param: ast.FunctionParam) => {
+          this.Visit(param, castedNode, currEnv);
+        });
+        this.Visit(castedNode.body, castedNode, currEnv);
+        castedNode.trailingComment.forEach((comment: ast.Comment) => {
+          this.Visit(comment, castedNode, currEnv);
+        });
+        return;
+      }
+      case "FunctionParamNode": {
+        const castedNode = <ast.FunctionParam>node;
+        castedNode.defaultValue && this.Visit(
+          castedNode.defaultValue, castedNode, currEnv);
+        return;
+      }
       case "IdentifierNode": {
         this.VisitIdentifier(<ast.Identifier>node);
         return;
@@ -110,10 +210,22 @@ export abstract class VisitorBase implements Visitor {
         // throw new Error(`${newEnv.get("fooModule")}`);
         return;
       }
-      // case "LiteralBooleanNode": return this.VisitLiteralBoolean(node);
-      // case "LiteralNullNode": return this.VisitLiteralNull(node);
+      case "LiteralBooleanNode": {
+        const castedNode = <ast.LiteralBoolean>node;
+        this.VisitLiteralBoolean(castedNode);
+        return;
+      }
+      case "LiteralNullNode": {
+        const castedNode = <ast.LiteralNull>node;
+        this.VisitLiteralNull(castedNode);
+        return;
+      }
       case "LiteralNumberNode": { return this.VisitLiteralNumber(<ast.LiteralNumber>node); }
-      // case "LiteralStringNode": return this.VisitLiteralString(node);
+      case "LiteralStringNode": {
+        const castedNode = <ast.LiteralString>node;
+        this.VisitLiteralString(castedNode);
+        return;
+      }
       case "ObjectFieldNode": {
         const castedNode = <ast.ObjectField>node;
         this.VisitObjectField(castedNode);
@@ -144,13 +256,62 @@ export abstract class VisitorBase implements Visitor {
         });
         return;
       }
-      // case "DesugaredObjectFieldNode": return this.VisitDesugaredObjectField(node);
-      // case "DesugaredObjectNode": return this.VisitDesugaredObject(node);
-      // case "ObjectCompNode": return this.VisitObjectComp(node);
-      // case "ObjectComprehensionSimpleNode": return this.VisitObjectComprehensionSimple(node);
-      // case "SelfNode": return this.VisitSelf(node);
-      // case "SuperIndexNode": return this.VisitSuperIndex(node);
-      // case "UnaryNode": return this.VisitUnary(node);
+      case "DesugaredObjectFieldNode": {
+        const castedNode = <ast.DesugaredObjectField>node;
+        this.VisitDesugaredObjectField(castedNode);
+        this.Visit(castedNode.name, castedNode, currEnv);
+        this.Visit(castedNode.body, castedNode, currEnv);
+        return;
+      }
+      case "DesugaredObjectNode": {
+        const castedNode = <ast.DesugaredObject>node;
+        this.VisitDesugaredObject(castedNode);
+        castedNode.asserts.forEach((a: ast.Assert) => {
+          this.Visit(a, castedNode, currEnv);
+        });
+        castedNode.fields.forEach((field: ast.DesugaredObjectField) => {
+          this.Visit(field, castedNode, currEnv);
+        });
+        return;
+      }
+      case "ObjectCompNode": {
+        const castedNode = <ast.ObjectComp>node;
+        this.VisitObjectComp(castedNode);
+        castedNode.specs.forEach((spec: ast.CompSpec) => {
+          this.Visit(spec, castedNode, currEnv);
+        });
+        castedNode.fields.forEach((field: ast.ObjectField) => {
+          this.Visit(field, castedNode, currEnv);
+        });
+        return;
+      }
+      case "ObjectComprehensionSimpleNode": {
+        const castedNode = <ast.ObjectComprehensionSimple>node;
+        this.VisitObjectComprehensionSimple(castedNode);
+        this.Visit(castedNode.id, castedNode, currEnv);
+        this.Visit(castedNode.field, castedNode, currEnv);
+        this.Visit(castedNode.value, castedNode, currEnv);
+        this.Visit(castedNode.array, castedNode, currEnv);
+        return;
+      }
+      case "SelfNode": {
+        const castedNode = <ast.Self>node;
+        this.VisitSelf(castedNode);
+        return;
+      }
+      case "SuperIndexNode": {
+        const castedNode = <ast.SuperIndex>node;
+        this.VisitSuperIndex(castedNode);
+        castedNode.index && this.Visit(castedNode.index, castedNode, currEnv);
+        castedNode.id && this.Visit(castedNode.id, castedNode, currEnv);
+        return;
+      }
+      case "UnaryNode": {
+        const castedNode = <ast.Unary>node;
+        this.VisitUnary(castedNode);
+        this.Visit(castedNode.expr, castedNode, currEnv);
+        return;
+      }
       case "VarNode": {
         const castedNode = <ast.Var>node;
         this.VisitVar(castedNode);
@@ -158,78 +319,84 @@ export abstract class VisitorBase implements Visitor {
         return
       }
       default: throw new Error(
-      `Visitor could not traverse tree; unknown node type '${node.type}'`);
+        `Visitor could not traverse tree; unknown node type '${node.type}'`);
     }
   }
 
   public abstract VisitComment = (node: ast.Comment): void => {}
-  // public abstract VisitCompSpec(node: ast.CompSpec): void
-  // public abstract VisitApply(node: ast.Apply): void
-  // public abstract VisitApplyBrace(node: ast.ApplyBrace): void
-  // public abstract VisitArray(node: ast.Array): void
-  // public abstract VisitArrayComp(node: ast.ArrayComp): void
-  // public abstract VisitAssert(node: ast.Assert): void
-  // public abstract VisitBinary(node: ast.Binary): void
-  // public abstract VisitBuiltin(node: ast.Builtin): void
-  // public abstract VisitConditional(node: ast.Conditional): void
-  // public abstract VisitDollar(node: ast.Dollar): void
-  // public abstract VisitError(node: ast.Error): void
-  // public abstract VisitFunction(node: ast.Function): void
+  public abstract VisitCompSpec = (node: ast.CompSpec): void => {}
+  public abstract VisitApply = (node: ast.Apply): void => {}
+  public abstract VisitApplyBrace = (node: ast.ApplyBrace): void => {}
+  public abstract VisitApplyParamAssignmentNode = (node: ast.ApplyParamAssignment): void => {}
+  public abstract VisitArray = (node: ast.Array): void => {}
+  public abstract VisitArrayComp = (node: ast.ArrayComp): void => {}
+  public abstract VisitAssert = (node: ast.Assert): void => {}
+  public abstract VisitBinary = (node: ast.Binary): void => {}
+  public abstract VisitBuiltin = (node: ast.Builtin): void => {}
+  public abstract VisitConditional = (node: ast.Conditional): void => {}
+  public abstract VisitDollar = (node: ast.Dollar): void => {}
+  public abstract VisitError = (node: ast.Error): void => {}
+  public abstract VisitFunction = (node: ast.Function): void => {}
+
   public abstract VisitIdentifier = (node: ast.Identifier): void => {}
   public abstract VisitImport = (node: ast.Import): void => {}
   public abstract VisitImportStr = (node: ast.ImportStr): void => {}
   public abstract VisitIndex = (node: ast.Index): void => {}
   // // public abstract VisitLocalBind(node: ast.LocalBind): void
   public abstract VisitLocal = (node: ast.Local): void => {}
-  // public abstract VisitLiteralBoolean(node: ast.LiteralBoolean): void
-  // public abstract VisitLiteralNull(node: ast.LiteralNull): void
+
+  public abstract VisitLiteralBoolean = (node: ast.LiteralBoolean): void => {}
+  public abstract VisitLiteralNull = (node: ast.LiteralNull): void => {}
+
   public abstract VisitLiteralNumber = (node: ast.LiteralNumber): void => {}
-  // public abstract VisitLiteralString(node: ast.LiteralString): void
+  public abstract VisitLiteralString = (node: ast.LiteralString): void => {}
   public abstract VisitObjectField = (node: ast.ObjectField): void => {}
   public abstract VisitObject = (node: ast.ObjectNode): void => {}
-  // public abstract VisitDesugaredObjectField(node: ast.DesugaredObjectField): void
-  // public abstract VisitDesugaredObject(node: ast.DesugaredObject): void
-  // public abstract VisitObjectComp(node: ast.ObjectComp): void
-  // public abstract VisitObjectComprehensionSimple(node: ast.ObjectComprehensionSimple): void
-  // public abstract VisitSelf(node: ast.Self): void
-  // public abstract VisitSuperIndex(node: ast.SuperIndex): void
-  // public abstract VisitUnary(node: ast.Unary): void
+  public abstract VisitDesugaredObjectField = (node: ast.DesugaredObjectField): void => {}
+  public abstract VisitDesugaredObject = (node: ast.DesugaredObject): void => {}
+  public abstract VisitObjectComp = (node: ast.ObjectComp): void => {}
+  public abstract VisitObjectComprehensionSimple = (node: ast.ObjectComprehensionSimple): void => {}
+  public abstract VisitSelf = (node: ast.Self): void => {}
+  public abstract VisitSuperIndex = (node: ast.SuperIndex): void => {}
+  public abstract VisitUnary = (node: ast.Unary): void => {}
   public abstract VisitVar = (node: ast.Var): void => {}
 }
 
 export class DeserializingVisitor extends VisitorBase {
   public VisitComment = (node: ast.Comment): void => {}
-  // public abstract VisitCompSpec(node: ast.CompSpec): void
-  // public abstract VisitApply(node: ast.Apply): void
-  // public abstract VisitApplyBrace(node: ast.ApplyBrace): void
-  // public abstract VisitArray(node: ast.Array): void
-  // public abstract VisitArrayComp(node: ast.ArrayComp): void
-  // public abstract VisitAssert(node: ast.Assert): void
-  // public abstract VisitBinary(node: ast.Binary): void
-  // public abstract VisitBuiltin(node: ast.Builtin): void
-  // public abstract VisitConditional(node: ast.Conditional): void
-  // public abstract VisitDollar(node: ast.Dollar): void
-  // public abstract VisitError(node: ast.Error): void
-  // public abstract VisitFunction(node: ast.Function): void
+  public VisitCompSpec = (node: ast.CompSpec): void => {}
+  public VisitApply = (node: ast.Apply): void => {}
+  public VisitApplyBrace = (node: ast.ApplyBrace): void => {}
+  public VisitApplyParamAssignmentNode = (node: ast.ApplyParamAssignment): void => {}
+  public VisitArray = (node: ast.Array): void => {}
+  public VisitArrayComp = (node: ast.ArrayComp): void => {}
+  public VisitAssert = (node: ast.Assert): void => {}
+  public VisitBinary = (node: ast.Binary): void => {}
+  public VisitBuiltin = (node: ast.Builtin): void => {}
+  public VisitConditional = (node: ast.Conditional): void => {}
+  public VisitDollar = (node: ast.Dollar): void => {}
+  public VisitError = (node: ast.Error): void => {}
+  public VisitFunction = (node: ast.Function): void => {}
+
   public VisitIdentifier = (node: ast.Identifier): void => {}
   public VisitImport = (node: ast.Import): void => {}
   public VisitImportStr = (node: ast.ImportStr): void => {}
   public VisitIndex = (node: ast.Index): void => {}
   // // public abstract VisitLocalBind(node: ast.LocalBind): void
   public VisitLocal = (node: ast.Local): void => {}
-  // public abstract VisitLiteralBoolean(node: ast.LiteralBoolean): void
-  // public abstract VisitLiteralNull(node: ast.LiteralNull): void
+  public VisitLiteralBoolean = (node: ast.LiteralBoolean): void => {}
+  public VisitLiteralNull = (node: ast.LiteralNull): void => {}
   public VisitLiteralNumber = (node: ast.LiteralNumber): void => {}
-  // public abstract VisitLiteralString(node: ast.LiteralString): void
+  public VisitLiteralString = (node: ast.LiteralString): void => {}
   public VisitObjectField = (node: ast.ObjectField): void => {}
   public VisitObject = (node: ast.ObjectNode): void => {}
-  // public abstract VisitDesugaredObjectField(node: ast.DesugaredObjectField): void
-  // public abstract VisitDesugaredObject(node: ast.DesugaredObject): void
-  // public abstract VisitObjectComp(node: ast.ObjectComp): void
-  // public abstract VisitObjectComprehensionSimple(node: ast.ObjectComprehensionSimple): void
-  // public abstract VisitSelf(node: ast.Self): void
-  // public abstract VisitSuperIndex(node: ast.SuperIndex): void
-  // public abstract VisitUnary(node: ast.Unary): void
+  public VisitDesugaredObjectField = (node: ast.DesugaredObjectField): void => {}
+  public VisitDesugaredObject = (node: ast.DesugaredObject): void => {}
+  public VisitObjectComp = (node: ast.ObjectComp): void => {}
+  public VisitObjectComprehensionSimple = (node: ast.ObjectComprehensionSimple): void => {}
+  public VisitSelf = (node: ast.Self): void => {}
+  public VisitSuperIndex = (node: ast.SuperIndex): void => {}
+  public VisitUnary = (node: ast.Unary): void => {}
   public VisitVar = (node: ast.Var): void => {}
 
 }
@@ -244,37 +411,39 @@ export class CursorVisitor extends VisitorBase {
   private tightestWrappingNode: ast.Node;
 
   public VisitComment = (node: ast.Comment): void => { this.updateIfCursorInRange(node); }
-  // public abstract VisitCompSpec(node: ast.CompSpec): void
-  // public abstract VisitApply(node: ast.Apply): void
-  // public abstract VisitApplyBrace(node: ast.ApplyBrace): void
-  // public abstract VisitArray(node: ast.Array): void
-  // public abstract VisitArrayComp(node: ast.ArrayComp): void
-  // public abstract VisitAssert(node: ast.Assert): void
-  // public abstract VisitBinary(node: ast.Binary): void
-  // public abstract VisitBuiltin(node: ast.Builtin): void
-  // public abstract VisitConditional(node: ast.Conditional): void
-  // public abstract VisitDollar(node: ast.Dollar): void
-  // public abstract VisitError(node: ast.Error): void
-  // public abstract VisitFunction(node: ast.Function): void
+  public VisitCompSpec = (node: ast.CompSpec): void => { this.updateIfCursorInRange(node); }
+  public VisitApply = (node: ast.Apply): void => { this.updateIfCursorInRange(node); }
+  public VisitApplyBrace = (node: ast.ApplyBrace): void => { this.updateIfCursorInRange(node); }
+  public VisitApplyParamAssignmentNode = (node: ast.ApplyParamAssignment): void => { this.updateIfCursorInRange(node); }
+  public VisitArray = (node: ast.Array): void => { this.updateIfCursorInRange(node); }
+  public VisitArrayComp = (node: ast.ArrayComp): void => { this.updateIfCursorInRange(node); }
+  public VisitAssert = (node: ast.Assert): void => { this.updateIfCursorInRange(node); }
+  public VisitBinary = (node: ast.Binary): void => { this.updateIfCursorInRange(node); }
+  public VisitBuiltin = (node: ast.Builtin): void => { this.updateIfCursorInRange(node); }
+  public VisitConditional = (node: ast.Conditional): void => { this.updateIfCursorInRange(node); }
+  public VisitDollar = (node: ast.Dollar): void => { this.updateIfCursorInRange(node); }
+  public VisitError = (node: ast.Error): void => { this.updateIfCursorInRange(node); }
+  public VisitFunction = (node: ast.Function): void => { this.updateIfCursorInRange(node); }
+
   public VisitIdentifier = (node: ast.Identifier): void => { this.updateIfCursorInRange(node); }
   public VisitImport = (node: ast.Import): void => { this.updateIfCursorInRange(node); }
   public VisitImportStr = (node: ast.ImportStr): void => { this.updateIfCursorInRange(node); }
   public VisitIndex = (node: ast.Index): void => { this.updateIfCursorInRange(node); }
   // // public abstract VisitLocalBind(node: ast.LocalBind): void
   public VisitLocal = (node: ast.Local): void => { this.updateIfCursorInRange(node); }
-  // public abstract VisitLiteralBoolean(node: ast.LiteralBoolean): void
-  // public abstract VisitLiteralNull(node: ast.LiteralNull): void
+  public VisitLiteralBoolean = (node: ast.LiteralBoolean): void => { this.updateIfCursorInRange(node); }
+  public VisitLiteralNull = (node: ast.LiteralNull): void => { this.updateIfCursorInRange(node); }
   public VisitLiteralNumber = (node: ast.LiteralNumber): void => { this.updateIfCursorInRange(node); }
-  // public abstract VisitLiteralString(node: ast.LiteralString): void
+  public VisitLiteralString = (node: ast.LiteralString): void => { this.updateIfCursorInRange(node); }
   public VisitObjectField = (node: ast.ObjectField): void => { this.updateIfCursorInRange(node); }
   public VisitObject = (node: ast.ObjectNode): void => { this.updateIfCursorInRange(node); }
-  // public abstract VisitDesugaredObjectField(node: ast.DesugaredObjectField): void
-  // public abstract VisitDesugaredObject(node: ast.DesugaredObject): void
-  // public abstract VisitObjectComp(node: ast.ObjectComp): void
-  // public abstract VisitObjectComprehensionSimple(node: ast.ObjectComprehensionSimple): void
-  // public abstract VisitSelf(node: ast.Self): void
-  // public abstract VisitSuperIndex(node: ast.SuperIndex): void
-  // public abstract VisitUnary(node: ast.Unary): void
+  public VisitDesugaredObjectField = (node: ast.DesugaredObjectField): void => { this.updateIfCursorInRange(node); }
+  public VisitDesugaredObject = (node: ast.DesugaredObject): void => { this.updateIfCursorInRange(node); }
+  public VisitObjectComp = (node: ast.ObjectComp): void => { this.updateIfCursorInRange(node); }
+  public VisitObjectComprehensionSimple = (node: ast.ObjectComprehensionSimple): void => { this.updateIfCursorInRange(node); }
+  public VisitSelf = (node: ast.Self): void => { this.updateIfCursorInRange(node); }
+  public VisitSuperIndex = (node: ast.SuperIndex): void => { this.updateIfCursorInRange(node); }
+  public VisitUnary = (node: ast.Unary): void => { this.updateIfCursorInRange(node); }
   public VisitVar = (node: ast.Var): void => { this.updateIfCursorInRange(node); }
 
   private updateIfCursorInRange = (node: ast.Node): ast.Node => {

--- a/server/lexer/lexer.ts
+++ b/server/lexer/lexer.ts
@@ -506,6 +506,7 @@ export class lexer {
               l.fileName,
               l.prevLocation());
           }
+          break;
         }
         case "numAfterDigit": {
           if (r.data === 'e' || r.data === 'E') {

--- a/server/lexer/lexer.ts
+++ b/server/lexer/lexer.ts
@@ -160,6 +160,8 @@ export class Token {
 
 export type Tokens = im.List<Token>;
 
+export const emptyTokens = im.List<Token>();
+
 // ---------------------------------------------------------------------------
 // Helpers
 

--- a/server/parser/node.ts
+++ b/server/parser/node.ts
@@ -46,11 +46,13 @@ export const renderAsJson = (node: Node): string => {
   node,
   (k, v) => {
     if (k === "parent") {
-      return (<Node>v).type;
+      return v == null
+        ? "null"
+        : (<Node>v).type;
     } else if (k === "env") {
-      // TODO: Calling `.has` on this causes us to claim that
-      // we can't find function. That's weird.
-      return `${Object.keys(v).join(", ")}`;
+      return v == null
+        ? "null"
+        : `${Object.keys(v).join(", ")}`;
     } else {
       return v;
     }

--- a/server/parser/node.ts
+++ b/server/parser/node.ts
@@ -102,7 +102,7 @@ export type NodeKind =
 // ---------------------------------------------------------------------------
 
 export interface Node {
-  readonly type:     string
+  readonly type:     NodeKind
   readonly loc:      error.LocationRange
   readonly freeVars: IdentifierNames
 

--- a/server/parser/node.ts
+++ b/server/parser/node.ts
@@ -103,6 +103,20 @@ export interface Identifier extends Node {
   readonly name: IdentifierName
 }
 
+export const makeIdentifier = (
+  name: string, loc: error.LocationRange
+): Identifier => {
+  return {
+    type:     "IdentifierNode",
+    loc:      loc,
+    name:     name,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
+
 // TODO(jbeda) implement interning of IdentifierNames if necessary.  The C++
 // version does so.
 
@@ -162,6 +176,24 @@ export interface Apply extends Node {
   readonly tailStrict:    boolean
 }
 
+export const makeApply = (
+  target: Node, args: Nodes, trailingComma: boolean,
+  tailStrict: boolean, loc: error.LocationRange,
+): Apply => {
+  return {
+    type:          "ApplyNode",
+    target:        target,
+    arguments:     args,
+    trailingComma: trailingComma,
+    tailStrict:    tailStrict,
+    loc:           loc,
+    freeVars:      im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
+
 // ---------------------------------------------------------------------------
 
 // ApplyBrace represents e { }.  Desugared to e + { }.
@@ -170,6 +202,21 @@ export interface ApplyBrace extends Node {
   readonly left:  Node
   readonly right: Node
 }
+
+export const makeApplyBrace = (
+  left: Node, right: Node, loc: error.LocationRange
+): ApplyBrace => {
+  return {
+    type:     "ApplyBraceNode",
+    left:     left,
+    right:    right,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
 
 // ---------------------------------------------------------------------------
 
@@ -182,6 +229,24 @@ export interface Array extends Node {
   readonly trailingComment: Comment | null
 }
 
+export const makeArray = (
+  elements: Nodes, trailingComma: boolean, headingComment: Comment | null,
+  trailingComment: Comment | null, loc: error.LocationRange,
+): Array => {
+  return {
+    type:            "ArrayNode",
+    loc:             loc,
+    elements:        elements,
+    trailingComma:   trailingComma,
+    headingComment:  headingComment,
+    trailingComment: trailingComment,
+    freeVars:        im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
+
 // ---------------------------------------------------------------------------
 
 // ArrayComp represents array comprehensions (which are like Python list
@@ -192,6 +257,23 @@ export interface ArrayComp extends Node {
   readonly trailingComma: boolean
   readonly specs:         CompSpecs
 }
+
+export const makeArrayComp = (
+  body: Node, trailingComma: boolean, specs: CompSpecs,
+  loc: error.LocationRange,
+): ArrayComp => {
+  return {
+    type:          "ArrayCompNode",
+    body:          body,
+    trailingComma: trailingComma,
+    specs:         specs,
+    loc:           loc,
+    freeVars:      im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
 
 // ---------------------------------------------------------------------------
 
@@ -205,6 +287,23 @@ export interface Assert extends Node {
   readonly message: Node | null
   readonly rest:    Node
 }
+
+export const makeAssert = (
+  cond: Node, message: Node | null, rest: Node,
+  loc: error.LocationRange,
+): Assert => {
+  return {
+    type:     "AssertNode",
+    cond:     cond,
+    message:  message,
+    rest:     rest,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
 
 // ---------------------------------------------------------------------------
 
@@ -296,6 +395,22 @@ export interface Binary extends Node {
   readonly right: Node
 }
 
+export const makeBinary = (
+  left: Node, op: BinaryOp, right: Node, loc: error.LocationRange,
+): Binary => {
+  return {
+    type:     "BinaryNode",
+    left:     left,
+    op:       op,
+    right:    right,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
+
 // ---------------------------------------------------------------------------
 
 // Builtin represents built-in functions.
@@ -321,10 +436,38 @@ export interface Conditional extends Node {
   readonly branchFalse: Node | null
 }
 
+export const makeConditional = (
+  cond: Node, branchTrue: Node, branchFalse: Node | null,
+  loc: error.LocationRange,
+): Conditional => {
+  return {
+    type:        "ConditionalNode",
+    cond:        cond,
+    branchTrue:  branchTrue,
+    branchFalse: branchFalse,
+    loc:         loc,
+    freeVars:    im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
+
 // ---------------------------------------------------------------------------
 
 // Dollar represents the $ keyword
 export interface Dollar extends Node { readonly type: "DollarNode" };
+
+export const makeDollar = (loc: error.LocationRange): Dollar => {
+  return {
+    type:     "DollarNode",
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  };
+};
 
 // ---------------------------------------------------------------------------
 
@@ -333,6 +476,18 @@ export interface Error extends Node {
   readonly type: "ErrorNode"
   readonly expr: Node
 }
+
+export const makeError = (expr: Node, loc: error.LocationRange): Error => {
+  return {
+    type:     "ErrorNode",
+    expr:     expr,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
 
 // ---------------------------------------------------------------------------
 
@@ -354,6 +509,18 @@ export interface Import extends Node {
   readonly file: string
 }
 
+export const makeImport = (file: string, loc: error.LocationRange): Import => {
+  return {
+    type:     "ImportNode",
+    file:     file,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
+
 // ---------------------------------------------------------------------------
 
 // ImportStr represents importstr "file".
@@ -361,6 +528,20 @@ export interface ImportStr extends Node {
   readonly type: "ImportStrNode"
   readonly file: string
 }
+
+export const makeImportStr = (
+  file: string, loc: error.LocationRange
+): ImportStr => {
+  return {
+    type:     "ImportStrNode",
+    file:     file,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
 
 // ---------------------------------------------------------------------------
 
@@ -375,6 +556,23 @@ export interface Index extends Node {
   readonly id:     Identifier | null
 }
 
+export const makeIndex = (
+  target: Node, index: Node | null, id: Identifier | null,
+  loc: error.LocationRange,
+): Index => {
+  return {
+    type:     "IndexNode",
+    target:   target,
+    index:    index,
+    id:       id,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
+
 // ---------------------------------------------------------------------------
 
 // LocalBind is a helper struct for Local
@@ -387,12 +585,40 @@ export interface LocalBind {
 }
 export type LocalBinds = im.List<LocalBind>
 
+export const makeLocalBind = (
+  variable: Identifier, body: Node, functionSugar: boolean,
+  params: IdentifierNames, trailingComma: boolean,
+): LocalBind => {
+  return {
+    variable:      variable,
+    body:          body,
+    functionSugar: functionSugar,
+    params:        params, // if functionSugar is true
+    trailingComma: trailingComma,
+  }
+};
+
 // Local represents local x = e; e.  After desugaring, functionSugar is false.
 export interface Local extends Node {
   readonly type:  "LocalNode"
   readonly binds: LocalBinds
   readonly body:  Node
 }
+
+export const makeLocal = (
+  binds: LocalBinds, body: Node, loc: error.LocationRange
+): Local => {
+  return {
+    type:     "LocalNode",
+    binds:    binds,
+    body:     body,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
 
 // ---------------------------------------------------------------------------
 
@@ -402,10 +628,35 @@ export interface LiteralBoolean extends Node {
   readonly value: boolean
 }
 
+export const makeLiteralBoolean = (
+  value: boolean, loc: error.LocationRange
+): LiteralBoolean => {
+  return {
+    type:     "LiteralBooleanNode",
+    value:    value,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
+
 // ---------------------------------------------------------------------------
 
 // LiteralNull represents the null keyword
 export interface LiteralNull extends Node { readonly type: "LiteralNullNode" }
+
+export const makeLiteralNull = (loc: error.LocationRange): LiteralNull => {
+  return {
+    type:     "LiteralNullNode",
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  };
+};
 
 // ---------------------------------------------------------------------------
 
@@ -415,6 +666,21 @@ export interface LiteralNumber extends Node {
   readonly value:          number
   readonly originalString: string
 }
+
+export const makeLiteralNumber = (
+  value: number, originalString: string, loc: error.LocationRange
+): LiteralNumber => {
+  return {
+    type:           "LiteralNumberNode",
+    value:          value,
+    originalString: originalString,
+    loc: loc,
+    freeVars:      im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
 
 // ---------------------------------------------------------------------------
 
@@ -434,6 +700,23 @@ export interface LiteralString extends Node {
 export const isLiteralString = (x: Node): x is LiteralString => {
     return x.type === "LiteralStringNode";
 }
+
+export const makeLiteralString = (
+  value: string, kind: LiteralStringKind, loc: error.LocationRange, blockIndent: string
+): LiteralString => {
+  return {
+    type:        "LiteralStringNode",
+    loc:         loc,
+    value:       value,
+    kind:        kind,
+    blockIndent: blockIndent,
+    freeVars:    im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
+
 
 // ---------------------------------------------------------------------------
 
@@ -491,6 +774,23 @@ export interface ObjectNode extends Node {
   readonly headingComments: Comments
 }
 
+export const makeObject = (
+  fields: ObjectFields, trailingComma: boolean,
+  headingComments: Comments, loc: error.LocationRange,
+): ObjectNode => {
+  return {
+    type: "ObjectNode",
+    loc: loc,
+    fields:          fields,
+    trailingComma:   trailingComma,
+    headingComments: headingComments,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
+
 // ---------------------------------------------------------------------------
 
 export interface DesugaredObjectField {
@@ -540,6 +840,17 @@ export interface ObjectComprehensionSimple extends Node {
 // Self represents the self keyword.
 export interface Self extends Node { readonly type: "SelfNode" };
 
+export const makeSelf = (loc: error.LocationRange): Self => {
+  return {
+    type:     "SelfNode",
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  };
+};
+
 // ---------------------------------------------------------------------------
 
 // SuperIndex represents the super[e] and super.f constructs.
@@ -551,6 +862,21 @@ export interface SuperIndex extends Node {
   readonly index: Node | null
   readonly id:    Identifier | null
 }
+
+export const makeSuperIndex = (
+  index: Node | null, id: Identifier | null, loc: error.LocationRange
+): SuperIndex => {
+  return {
+    type:     "SuperIndexNode",
+    index:    index,
+    id:       id,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
 
 // ---------------------------------------------------------------------------
 
@@ -581,6 +907,21 @@ export interface Unary extends Node {
   readonly expr: Node
 }
 
+export const makeUnary = (
+  op: UnaryOp, expr: Node, loc: error.LocationRange,
+): Unary => {
+  return {
+    type:     "UnaryNode",
+    op:       op,
+    expr:     expr,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+};
+
 // ---------------------------------------------------------------------------
 
 // Var represents variables.
@@ -592,5 +933,17 @@ export interface Var extends Node {
 export const isVar = (x: Node): x is Var => {
     return x.type === "VarNode";
 }
+
+export const makeVar = (id: Identifier, loc: error.LocationRange): Var => {
+  return {
+    type:     "VarNode",
+    id:       id,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  };
+};
 
 // ---------------------------------------------------------------------------

--- a/server/parser/node.ts
+++ b/server/parser/node.ts
@@ -103,6 +103,10 @@ export interface Identifier extends Node {
   readonly name: IdentifierName
 }
 
+export const isIdentifier = (node: Node): node is Identifier => {
+    return node.type === "IdentifierNode";
+}
+
 export const makeIdentifier = (
   name: string, loc: error.LocationRange
 ): Identifier => {
@@ -556,6 +560,10 @@ export interface Index extends Node {
   readonly id:     Identifier | null
 }
 
+export const isIndex = (node: any): node is Index => {
+    return node.type === "IndexNode";
+}
+
 export const makeIndex = (
   target: Node, index: Node | null, id: Identifier | null,
   loc: error.LocationRange,
@@ -749,18 +757,6 @@ export interface ObjectField extends Node {
 
 // TODO(jbeda): Add the remaining constructor helpers here
 
-// func MakeObjectFieldBase(loc LocationRange) NodeBase {
-//   return MakeNodeBase(, loc, IdentifierNames{})
-// }
-
-// func ObjectFieldLocal(methodSugar bool, id *Identifier, ids IdentifierNames, trailingComma bool, body Node) ObjectField {
-//   return ObjectField{MakeObjectFieldBase(*body.LocationRange()), ObjectLocal, ObjectFieldVisible, false, methodSugar, nil, id, ids, trailingComma, body, nil, nil}
-// }
-
-// func ObjectFieldLocalNoMethod(id *Identifier, body Node) ObjectField {
-//   return ObjectField{MakeObjectFieldBase(*body.LocationRange()), ObjectLocal, ObjectFieldVisible, false, false, nil, id, IdentifierNames{}, false, body, nil, nil}
-// }
-
 export type ObjectFields = im.List<ObjectField>;
 
 // Object represents object constructors { f: e ... }.
@@ -772,6 +768,10 @@ export interface ObjectNode extends Node {
   readonly fields:          ObjectFields
   readonly trailingComma:   boolean
   readonly headingComments: Comments
+}
+
+export const isObjectNode = (node: any): node is ObjectNode => {
+    return node.type === "ObjectNode";
 }
 
 export const makeObject = (

--- a/server/parser/node.ts
+++ b/server/parser/node.ts
@@ -106,7 +106,8 @@ export interface Identifier extends Node {
 }
 
 export const isIdentifier = (node: Node): node is Identifier => {
-    return node.type === "IdentifierNode";
+  const nodeType: NodeKind = "IdentifierNode";
+  return node.type === nodeType;
 }
 
 export const makeIdentifier = (
@@ -141,6 +142,11 @@ export interface Comment extends Node {
   readonly text: string
 };
 export type Comments = im.List<Comment>;
+
+export const isComment = (node: Node): node is Comment => {
+  const nodeType: NodeKind = "CommentNode";
+  return node.type === nodeType;
+}
 
 export const MakeCppComment = (
   loc: error.LocationRange, text: string
@@ -180,6 +186,11 @@ export interface Apply extends Node {
   readonly arguments:     Nodes
   readonly trailingComma: boolean
   readonly tailStrict:    boolean
+}
+
+export const isApply = (node: Node): node is Apply => {
+  const nodeType: NodeKind = "ApplyNode";
+  return node.type === nodeType;
 }
 
 export const makeApply = (
@@ -238,6 +249,11 @@ export interface ApplyBrace extends Node {
   readonly right: Node
 }
 
+export const isApplyBrace = (node: Node): node is ApplyBrace => {
+  const nodeType: NodeKind = "ApplyBraceNode";
+  return node.type === nodeType;
+}
+
 export const makeApplyBrace = (
   left: Node, right: Node, loc: error.LocationRange
 ): ApplyBrace => {
@@ -262,6 +278,11 @@ export interface Array extends Node {
   readonly trailingComma:   boolean
   readonly headingComment:  Comment | null
   readonly trailingComment: Comment | null
+}
+
+export const isArray = (node: Node): node is Array => {
+  const nodeType: NodeKind = "ArrayNode";
+  return node.type === nodeType;
 }
 
 export const makeArray = (
@@ -293,6 +314,11 @@ export interface ArrayComp extends Node {
   readonly specs:         CompSpecs
 }
 
+export const isArrayComp = (node: Node): node is ArrayComp => {
+  const nodeType: NodeKind = "ArrayCompNode";
+  return node.type === nodeType;
+}
+
 export const makeArrayComp = (
   body: Node, trailingComma: boolean, specs: CompSpecs,
   loc: error.LocationRange,
@@ -321,6 +347,11 @@ export interface Assert extends Node {
   readonly cond:    Node
   readonly message: Node | null
   readonly rest:    Node
+}
+
+export const isAssert = (node: Node): node is Assert => {
+  const nodeType: NodeKind = "AssertNode";
+  return node.type === nodeType;
 }
 
 export const makeAssert = (
@@ -430,6 +461,11 @@ export interface Binary extends Node {
   readonly right: Node
 }
 
+export const isBinary = (node: Node): node is Binary => {
+  const nodeType: NodeKind = "BinaryNode";
+  return node.type === nodeType;
+}
+
 export const makeBinary = (
   left: Node, op: BinaryOp, right: Node, loc: error.LocationRange,
 ): Binary => {
@@ -458,6 +494,11 @@ export interface Builtin extends Node {
   readonly params: IdentifierNames
 }
 
+export const isBuiltin = (node: Node): node is Builtin => {
+  const nodeType: NodeKind = "BuiltinNode";
+  return node.type === nodeType;
+}
+
 // ---------------------------------------------------------------------------
 
 // Conditional represents if/then/else.
@@ -469,6 +510,11 @@ export interface Conditional extends Node {
   readonly cond:        Node
   readonly branchTrue:  Node
   readonly branchFalse: Node | null
+}
+
+export const isConditional = (node: Node): node is Conditional => {
+  const nodeType: NodeKind = "ConditionalNode";
+  return node.type === nodeType;
 }
 
 export const makeConditional = (
@@ -493,6 +539,11 @@ export const makeConditional = (
 // Dollar represents the $ keyword
 export interface Dollar extends Node { readonly type: "DollarNode" };
 
+export const isDollar = (node: Node): node is Dollar => {
+  const nodeType: NodeKind = "DollarNode";
+  return node.type === nodeType;
+}
+
 export const makeDollar = (loc: error.LocationRange): Dollar => {
   return {
     type:     "DollarNode",
@@ -510,6 +561,11 @@ export const makeDollar = (loc: error.LocationRange): Dollar => {
 export interface Error extends Node {
   readonly type: "ErrorNode"
   readonly expr: Node
+}
+
+export const isError = (node: Node): node is Error => {
+  const nodeType: NodeKind = "ErrorNode";
+  return node.type === nodeType;
 }
 
 export const makeError = (expr: Node, loc: error.LocationRange): Error => {
@@ -536,12 +592,22 @@ export interface Function extends Node {
   readonly trailingComment: Comments
 }
 
+export const isFunction = (node: Node): node is Function => {
+  const nodeType: NodeKind = "FunctionNode";
+  return node.type === nodeType;
+}
+
 export interface FunctionParam extends Node {
   readonly type:         "FunctionParamNode"
   readonly id:           IdentifierName
   readonly defaultValue: Node | null
 }
 export type FunctionParams = im.List<FunctionParam>
+
+export const isFunctionParam = (node: Node): node is FunctionParam => {
+  const nodeType: NodeKind = "FunctionParamNode";
+  return node.type === nodeType;
+}
 
 export const makeFunctionParam = (
   id: IdentifierName, loc: error.LocationRange,
@@ -567,6 +633,11 @@ export interface Import extends Node {
   readonly file: string
 }
 
+export const isImport = (node: Node): node is Import => {
+  const nodeType: NodeKind = "ImportNode";
+  return node.type === nodeType;
+}
+
 export const makeImport = (file: string, loc: error.LocationRange): Import => {
   return {
     type:     "ImportNode",
@@ -585,6 +656,11 @@ export const makeImport = (file: string, loc: error.LocationRange): Import => {
 export interface ImportStr extends Node {
   readonly type: "ImportStrNode"
   readonly file: string
+}
+
+export const isImportStr = (node: Node): node is ImportStr => {
+  const nodeType: NodeKind = "ImportStrNode";
+  return node.type === nodeType;
 }
 
 export const makeImportStr = (
@@ -614,8 +690,9 @@ export interface Index extends Node {
   readonly id:     Identifier | null
 }
 
-export const isIndex = (node: any): node is Index => {
-    return node.type === "IndexNode";
+export const isIndex = (node: Node): node is Index => {
+  const nodeType: NodeKind = "IndexNode";
+  return node.type === nodeType;
 }
 
 export const makeIndex = (
@@ -667,6 +744,11 @@ export interface Local extends Node {
   readonly body:  Node
 }
 
+export const isLocal = (node: Node): node is Local => {
+  const nodeType: NodeKind = "LocalNode";
+  return node.type === nodeType;
+}
+
 export const makeLocal = (
   binds: LocalBinds, body: Node, loc: error.LocationRange
 ): Local => {
@@ -690,6 +772,11 @@ export interface LiteralBoolean extends Node {
   readonly value: boolean
 }
 
+export const isLiteralBoolean = (node: Node): node is LiteralBoolean => {
+  const nodeType: NodeKind = "LiteralBooleanNode";
+  return node.type === nodeType;
+}
+
 export const makeLiteralBoolean = (
   value: boolean, loc: error.LocationRange
 ): LiteralBoolean => {
@@ -709,6 +796,11 @@ export const makeLiteralBoolean = (
 // LiteralNull represents the null keyword
 export interface LiteralNull extends Node { readonly type: "LiteralNullNode" }
 
+export const isLiteralNull = (node: Node): node is LiteralNull => {
+  const nodeType: NodeKind = "LiteralNullNode";
+  return node.type === nodeType;
+}
+
 export const makeLiteralNull = (loc: error.LocationRange): LiteralNull => {
   return {
     type:     "LiteralNullNode",
@@ -727,6 +819,11 @@ export interface LiteralNumber extends Node {
   readonly type:           "LiteralNumberNode"
   readonly value:          number
   readonly originalString: string
+}
+
+export const isLiteralNumber = (node: Node): node is LiteralNumber => {
+  const nodeType: NodeKind = "LiteralNumberNode";
+  return node.type === nodeType;
 }
 
 export const makeLiteralNumber = (
@@ -759,8 +856,9 @@ export interface LiteralString extends Node {
   readonly blockIndent: string
 }
 
-export const isLiteralString = (x: Node): x is LiteralString => {
-    return x.type === "LiteralStringNode";
+export const isLiteralString = (node: Node): node is LiteralString => {
+  const nodeType: NodeKind = "LiteralStringNode";
+  return node.type === nodeType;
 }
 
 export const makeLiteralString = (
@@ -809,6 +907,11 @@ export interface ObjectField extends Node {
   readonly headingComments: Comments
 }
 
+export const isObjectField = (node: Node): node is ObjectField => {
+  const nodeType: NodeKind = "ObjectFieldNode";
+  return node.type === nodeType;
+}
+
 // TODO(jbeda): Add the remaining constructor helpers here
 
 export type ObjectFields = im.List<ObjectField>;
@@ -824,8 +927,9 @@ export interface ObjectNode extends Node {
   readonly headingComments: Comments
 }
 
-export const isObjectNode = (node: any): node is ObjectNode => {
-    return node.type === "ObjectNode";
+export const isObjectNode = (node: Node): node is ObjectNode => {
+  const nodeType: NodeKind = "ObjectNode";
+  return node.type === nodeType;
 }
 
 export const makeObject = (
@@ -864,6 +968,11 @@ export interface DesugaredObject extends Node {
   readonly fields:  DesugaredObjectFields
 }
 
+export const isDesugaredObject = (node: Node): node is DesugaredObject => {
+  const nodeType: NodeKind = "DesugaredObjectNode";
+  return node.type === nodeType;
+}
+
 // ---------------------------------------------------------------------------
 
 // ObjectComp represents object comprehension
@@ -873,6 +982,11 @@ export interface ObjectComp extends Node {
   readonly fields:        ObjectFields
   readonly trailingComma: boolean
   readonly specs:         CompSpecs
+}
+
+export const isObjectComp = (node: Node): node is ObjectComp => {
+  const nodeType: NodeKind = "ObjectCompNode";
+  return node.type === nodeType;
 }
 
 // ---------------------------------------------------------------------------
@@ -889,10 +1003,22 @@ export interface ObjectComprehensionSimple extends Node {
   readonly array: Node
 }
 
+export const isObjectComprehensionSimple = (
+  node: Node
+): node is ObjectComprehensionSimple => {
+  const nodeType: NodeKind = "ObjectComprehensionSimpleNode";
+  return node.type === nodeType;
+}
+
 // ---------------------------------------------------------------------------
 
 // Self represents the self keyword.
 export interface Self extends Node { readonly type: "SelfNode" };
+
+export const isSelf = (node: Node): node is Self => {
+  const nodeType: NodeKind = "SelfNode";
+  return node.type === nodeType;
+}
 
 export const makeSelf = (loc: error.LocationRange): Self => {
   return {
@@ -915,6 +1041,11 @@ export interface SuperIndex extends Node {
   readonly type: "SuperIndexNode"
   readonly index: Node | null
   readonly id:    Identifier | null
+}
+
+export const isSuperIndex = (node: Node): node is SuperIndex => {
+  const nodeType: NodeKind = "SuperIndexNode";
+  return node.type === nodeType;
 }
 
 export const makeSuperIndex = (
@@ -961,6 +1092,11 @@ export interface Unary extends Node {
   readonly expr: Node
 }
 
+export const isUnary = (node: Node): node is Unary => {
+  const nodeType: NodeKind = "UnaryNode";
+  return node.type === nodeType;
+}
+
 export const makeUnary = (
   op: UnaryOp, expr: Node, loc: error.LocationRange,
 ): Unary => {
@@ -984,8 +1120,9 @@ export interface Var extends Node {
   readonly id: Identifier
 }
 
-export const isVar = (x: Node): x is Var => {
-    return x.type === "VarNode";
+export const isVar = (node: Node): node is Var => {
+  const nodeType: NodeKind = "VarNode";
+  return node.type === nodeType;
 }
 
 export const makeVar = (id: Identifier, loc: error.LocationRange): Var => {

--- a/server/parser/node.ts
+++ b/server/parser/node.ts
@@ -170,12 +170,35 @@ export type CompKind =
   "CompFor" |
   "CompIf";
 
-export interface CompSpec {
+export interface CompSpec extends Node {
+  readonly type:    "CompSpecNode"
   readonly kind:    CompKind
   readonly varName: Identifier | null // null when kind != compSpecFor
   readonly expr:    Node
 };
 export type CompSpecs = im.List<CompSpec>;
+
+export const isCompSpec = (node: Node): node is CompSpec => {
+  const nodeType: NodeKind = "CompSpecNode";
+  return node.type === nodeType;
+}
+
+export const makeCompSpec = (
+  kind: CompKind, varName: Identifier | null, expr: Node,
+  loc: error.LocationRange,
+): CompSpec => {
+  return {
+    type:     "CompSpecNode",
+    kind:     kind,
+    varName:  varName,
+    expr:     expr,
+    loc:      loc,
+    freeVars: im.List<IdentifierName>(),
+
+    parent: null,
+    env: null,
+  }
+}
 
 // ---------------------------------------------------------------------------
 
@@ -951,7 +974,8 @@ export const makeObject = (
 
 // ---------------------------------------------------------------------------
 
-export interface DesugaredObjectField {
+export interface DesugaredObjectField extends Node {
+  readonly type: "DesugaredObjectFieldNode"
   readonly hide: ObjectFieldHide
   readonly name: Node
   readonly body: Node

--- a/server/parser/node.ts
+++ b/server/parser/node.ts
@@ -431,6 +431,10 @@ export interface LiteralString extends Node {
   readonly blockIndent: string
 }
 
+export const isLiteralString = (x: Node): x is LiteralString => {
+    return x.type === "LiteralStringNode";
+}
+
 // ---------------------------------------------------------------------------
 
 export type ObjectFieldKind =
@@ -583,6 +587,10 @@ export interface Unary extends Node {
 export interface Var extends Node {
   readonly type: "VarNode"
   readonly id: Identifier
+}
+
+export const isVar = (x: Node): x is Var => {
+    return x.type === "VarNode";
 }
 
 // ---------------------------------------------------------------------------

--- a/server/parser/parser.ts
+++ b/server/parser/parser.ts
@@ -573,12 +573,12 @@ class parser {
       //     // Explains `foo`.
       //     , foo: "bar"
       //
-      // To accomodate both styles, we attempt to parse comments before
-      // and after the comma. If there are comments after, that is
-      // becomes the heading comment for that field; if not, then we use
-      // any comments that happen after the line that contains the last
-      // field, but before the comma. So, for example, we ignore the
-      // following comment:
+      // To accomodate both styles, we attempt to parse comments
+      // before and after the comma. If there are comments after, that
+      // is becomes the heading comment for that field; if not, then
+      // we use any comments that happen after the line that contains
+      // the last field, but before the comma. So, for example, we
+      // ignore the following comment:
       //
       //     , foo: "value1" // This comment is not a heading comment.
       //     // But this one is.
@@ -796,8 +796,8 @@ class parser {
       this.parseOptionalComments();
     }
 
-    // TODO: Remove trailing whitespace here after we emit newlines from
-    // the lexer. If we don't do that, we might accidentally kill
+    // TODO: Remove trailing whitespace here after we emit newlines
+    // from the lexer. If we don't do that, we might accidentally kill
     // comments that correspond to, e.g., the next field of an object.
 
     return ast.makeArray(elements, gotComma, null, null, locFromTokens(tok, next));
@@ -858,8 +858,8 @@ class parser {
 
       // Literals
       case "TokenNumber": {
-        // This shouldn't fail as the lexer should make sure we have good input but
-        // we handle the error regardless.
+        // This shouldn't fail as the lexer should make sure we have
+        // good input but we handle the error regardless.
         const num = Number(tok.data);
         // TODO: Figure out whether this is correct.
         if (isNaN(num) && tok.data !== "NaN") {
@@ -952,8 +952,8 @@ class parser {
     }
 
     switch (begin.kind) {
-      // These cases have effectively maxPrecedence as the first
-      // call to parse will parse them.
+      // These cases have effectively maxPrecedence as the first call
+      // to parse will parse them.
       case "TokenAssert": {
         this.pop();
         const cond = this.parse(maxPrecedence, im.List<ast.Comment>());
@@ -1131,17 +1131,18 @@ class parser {
 
           let bop: ast.BinaryOp | null = null;
 
-          // Check precedence is correct for this level.  If we're parsing operators
-          // with higher precedence, then return lhs and let lower levels deal with
-          // the operator.
+          // Check precedence is correct for this level.  If we're
+          // parsing operators with higher precedence, then return lhs
+          // and let lower levels deal with the operator.
           switch (this.peek().kind) {
             case "TokenOperator": {
               // _ = "breakpoint"
               if (this.peek().data === ":") {
-                // Special case for the colons in assert. Since COLON is no-longer a
-                // special token, we have to make sure it does not trip the
-                // op_is_binary test below.  It should terminate parsing of the
-                // expression here, returning control to the parsing of the actual
+                // Special case for the colons in assert. Since COLON
+                // is no-longer a special token, we have to make sure
+                // it does not trip the op_is_binary test below.  It
+                // should terminate parsing of the expression here,
+                // returning control to the parsing of the actual
                 // assert AST.
                 return lhs;
               }

--- a/server/parser/parser.ts
+++ b/server/parser/parser.ts
@@ -7,358 +7,6 @@ import * as lexer from '../lexer/lexer';
 
 // ---------------------------------------------------------------------------
 
-const makeLiteralString = (
-  value: string, kind: ast.LiteralStringKind, loc: error.LocationRange, blockIndent: string
-): ast.LiteralString => {
-  return {
-    type:        "LiteralStringNode",
-    loc:         loc,
-    value:       value,
-    kind:        kind,
-    blockIndent: blockIndent,
-    freeVars:    im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-};
-
-const makeIdentifier = (
-  name: string, loc: error.LocationRange
-): ast.Identifier => {
-  return {
-    type:     "IdentifierNode",
-    loc:      loc,
-    name:     name,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeObject = (
-  fields: ast.ObjectFields, trailingComma: boolean,
-  headingComments: ast.Comments, loc: error.LocationRange,
-): ast.ObjectNode => {
-  return {
-    type: "ObjectNode",
-    loc: loc,
-    fields:          fields,
-    trailingComma:   trailingComma,
-    headingComments: headingComments,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeArray = (
-  elements: ast.Nodes, trailingComma: boolean, headingComment: ast.Comment | null,
-  trailingComment: ast.Comment | null, loc: error.LocationRange,
-): ast.Array => {
-  return {
-    type:            "ArrayNode",
-    loc:             loc,
-    elements:        elements,
-    trailingComma:   trailingComma,
-    headingComment:  headingComment,
-    trailingComment: trailingComment,
-    freeVars:        im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeArrayComp = (
-  body: ast.Node, trailingComma: boolean, specs: ast.CompSpecs,
-  loc: error.LocationRange,
-): ast.ArrayComp => {
-  return {
-    type:          "ArrayCompNode",
-    body:          body,
-    trailingComma: trailingComma,
-    specs:         specs,
-    loc:           loc,
-    freeVars:      im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeLiteralNumber = (
-  value: number, originalString: string, loc: error.LocationRange
-): ast.LiteralNumber => {
-  return {
-    type:           "LiteralNumberNode",
-    value:          value,
-    originalString: originalString,
-    loc: loc,
-    freeVars:      im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeLiteralBoolean = (
-  value: boolean, loc: error.LocationRange
-): ast.LiteralBoolean => {
-  return {
-    type:     "LiteralBooleanNode",
-    value:    value,
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeLiteralNull = (loc: error.LocationRange): ast.LiteralNull => {
-  return {
-    type:     "LiteralNullNode",
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  };
-}
-
-const makeDollar = (loc: error.LocationRange): ast.Dollar => {
-  return {
-    type:     "DollarNode",
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  };
-}
-
-const makeSelf = (loc: error.LocationRange): ast.Self => {
-  return {
-    type:     "SelfNode",
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  };
-}
-
-const makeVar = (id: ast.Identifier, loc: error.LocationRange): ast.Var => {
-  return {
-    type:     "VarNode",
-    id:       id,
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  };
-}
-
-const makeSuperIndex = (
-  index: ast.Node | null, id: ast.Identifier | null, loc: error.LocationRange
-): ast.SuperIndex => {
-  return {
-    type:     "SuperIndexNode",
-    index:    index,
-    id:       id,
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeAssert = (
-  cond: ast.Node, message: ast.Node | null, rest: ast.Node,
-  loc: error.LocationRange,
-): ast.Assert => {
-  return {
-    type:     "AssertNode",
-    cond:     cond,
-    message:  message,
-    rest:     rest,
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeError = (expr: ast.Node, loc: error.LocationRange): ast.Error => {
-  return {
-    type:     "ErrorNode",
-    expr:     expr,
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeConditional = (
-  cond: ast.Node, branchTrue: ast.Node, branchFalse: ast.Node | null,
-  loc: error.LocationRange,
-): ast.Conditional => {
-  return {
-    type:        "ConditionalNode",
-    cond:        cond,
-    branchTrue:  branchTrue,
-    branchFalse: branchFalse,
-    loc:         loc,
-    freeVars:    im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeImport = (file: string, loc: error.LocationRange): ast.Import => {
-  return {
-    type:     "ImportNode",
-    file:     file,
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeImportStr = (
-  file: string, loc: error.LocationRange
-): ast.ImportStr => {
-  return {
-    type:     "ImportStrNode",
-    file:     file,
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeLocal = (
-  binds: ast.LocalBinds, body: ast.Node, loc: error.LocationRange
-): ast.Local => {
-  return {
-    type:     "LocalNode",
-    binds:    binds,
-    body:     body,
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeUnary = (
-  op: ast.UnaryOp, expr: ast.Node, loc: error.LocationRange,
-): ast.Unary => {
-  return {
-    type:     "UnaryNode",
-    op:       op,
-    expr:     expr,
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeIndex = (
-  target: ast.Node, index: ast.Node | null, id: ast.Identifier | null,
-  loc: error.LocationRange,
-): ast.Index => {
-  return {
-    type:     "IndexNode",
-    target:   target,
-    index:    index,
-    id:       id,
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeApply = (
-  target: ast.Node, args: ast.Nodes, trailingComma: boolean,
-  tailStrict: boolean, loc: error.LocationRange,
-): ast.Apply => {
-  return {
-    type:          "ApplyNode",
-    target:        target,
-    arguments:     args,
-    trailingComma: trailingComma,
-    tailStrict:    tailStrict,
-    loc:           loc,
-    freeVars:      im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeApplyBrace = (
-  left: ast.Node, right: ast.Node, loc: error.LocationRange
-): ast.ApplyBrace => {
-  return {
-    type:     "ApplyBraceNode",
-    left:     left,
-    right:    right,
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeBinary = (
-  left: ast.Node, op: ast.BinaryOp, right: ast.Node, loc: error.LocationRange,
-): ast.Binary => {
-  return {
-    type:     "BinaryNode",
-    left:     left,
-    op:       op,
-    right:    right,
-    loc:      loc,
-    freeVars: im.List<ast.IdentifierName>(),
-
-    parent: null,
-    env: null,
-  }
-}
-
-const makeLocalBind = (
-  variable: ast.Identifier, body: ast.Node, functionSugar: boolean,
-  params: ast.IdentifierNames, trailingComma: boolean,
-): ast.LocalBind => {
-  return {
-    variable:      variable,
-    body:          body,
-    functionSugar: functionSugar,
-    params:        params, // if functionSugar is true
-    trailingComma: trailingComma,
-  }
-}
-
 type precedence = number;
 
 const applyPrecedence: precedence = 2,  // Function calls and indexing.
@@ -563,9 +211,9 @@ class parser {
       if (error.isStaticError(body)) {
         return body;
       }
-      const id = makeIdentifier(varID.data, varID.loc);
+      const id = ast.makeIdentifier(varID.data, varID.loc);
       const {ids: params, gotComma: gotComma} = result;
-      const bind = makeLocalBind(id, body, true, params, gotComma);
+      const bind = ast.makeLocalBind(id, body, true, params, gotComma);
       binds = binds.push(bind);
     } else {
       const pop = p.popExpectOp("=");
@@ -576,8 +224,8 @@ class parser {
       if (error.isStaticError(body)) {
         return body;
       }
-      const id = makeIdentifier(varID.data, varID.loc);
-      const bind = makeLocalBind(id, body, false, im.List<string>(), false)
+      const id = ast.makeIdentifier(varID.data, varID.loc);
+      const bind = ast.makeLocalBind(id, body, false, im.List<string>(), false)
       binds = binds.push(bind);
     }
 
@@ -708,22 +356,22 @@ class parser {
     switch (next.kind) {
       case "TokenIdentifier": {
         kind = "ObjectFieldID";
-        id = makeIdentifier(next.data, next.loc);
+        id = ast.makeIdentifier(next.data, next.loc);
         break;
       }
       case "TokenStringDouble": {
         kind = "ObjectFieldStr";
-        expr1 = makeLiteralString(next.data, "StringDouble", next.loc, "");
+        expr1 = ast.makeLiteralString(next.data, "StringDouble", next.loc, "");
         break;
       }
       case "TokenStringSingle": {
         kind = "ObjectFieldStr";
-        expr1 = makeLiteralString(next.data, "StringSingle", next.loc, "");
+        expr1 = ast.makeLiteralString(next.data, "StringSingle", next.loc, "");
         break;
       }
       case "TokenStringBlock": {
         kind = "ObjectFieldStr"
-        expr1 = makeLiteralString(
+        expr1 = ast.makeLiteralString(
           next.data, "StringBlock", next.loc, next.stringBlockIndent);
         break;
       }
@@ -816,7 +464,7 @@ class parser {
     if (error.isStaticError(varID)) {
       return varID;
     }
-    const id = makeIdentifier(varID.data, varID.loc);
+    const id = ast.makeIdentifier(varID.data, varID.loc);
     if (binds.contains(id.name)) {
       return error.MakeStaticError(
         `Duplicate local var: ${id.name}`, varID.loc);
@@ -972,7 +620,7 @@ class parser {
       // Done parsing the object. Return.
       if (next.kind === "TokenBraceR") {
         return {
-          objRemainder: makeObject(
+          objRemainder: ast.makeObject(
             fields, gotComma, heading, locFromTokens(tok, next)),
           next: next
         };
@@ -1057,7 +705,7 @@ class parser {
         return varID;
       }
 
-      const id: ast.Identifier = makeIdentifier(varID.data, varID.loc);
+      const id: ast.Identifier = ast.makeIdentifier(varID.data, varID.loc);
       const pop = p.popExpect("TokenIn");
       if (error.isStaticError(pop)) {
         return pop;
@@ -1107,7 +755,7 @@ class parser {
     let next = p.peek();
     if (next.kind === "TokenBracketR") {
       p.pop();
-      return makeArray(
+      return ast.makeArray(
         im.List<ast.Node>(), false, null, null, locFromTokens(tok, next));
     }
 
@@ -1131,7 +779,7 @@ class parser {
         return result;
       }
 
-      return makeArrayComp(
+      return ast.makeArrayComp(
         first, gotComma, result.compSpecs, locFromTokens(tok, result.maybeIf));
     }
     // Not a comprehension: It can have more elements.
@@ -1173,7 +821,7 @@ class parser {
     // the lexer. If we don't do that, we might accidentally kill
     // comments that correspond to, e.g., the next field of an object.
 
-    return makeArray(elements, gotComma, null, null, locFromTokens(tok, next));
+    return ast.makeArray(elements, gotComma, null, null, locFromTokens(tok, next));
   };
 
   public parseTerminal = (
@@ -1241,31 +889,31 @@ class parser {
           return error.MakeStaticError(
             "Could not parse floating point number.", tok.loc);
         }
-        return makeLiteralNumber(num, tok.data, tok.loc);
+        return ast.makeLiteralNumber(num, tok.data, tok.loc);
       }
       case "TokenStringSingle":
-        return makeLiteralString(tok.data, "StringSingle", tok.loc, "");
+        return ast.makeLiteralString(tok.data, "StringSingle", tok.loc, "");
       case "TokenStringDouble":
-        return makeLiteralString(tok.data, "StringDouble", tok.loc, "");
+        return ast.makeLiteralString(tok.data, "StringDouble", tok.loc, "");
       case "TokenStringBlock":
-        return makeLiteralString(
+        return ast.makeLiteralString(
           tok.data, "StringBlock", tok.loc, tok.stringBlockIndent);
       case "TokenFalse":
-        return makeLiteralBoolean(false, tok.loc);
+        return ast.makeLiteralBoolean(false, tok.loc);
       case "TokenTrue":
-        return makeLiteralBoolean(true, tok.loc);
+        return ast.makeLiteralBoolean(true, tok.loc);
       case "TokenNullLit":
-        return makeLiteralNull(tok.loc);
+        return ast.makeLiteralNull(tok.loc);
 
       // Variables
       case "TokenDollar":
-        return makeDollar(tok.loc);
+        return ast.makeDollar(tok.loc);
       case "TokenIdentifier": {
-        const id = makeIdentifier(tok.data, tok.loc);
-        return makeVar(id, tok.loc);
+        const id = ast.makeIdentifier(tok.data, tok.loc);
+        return ast.makeVar(id, tok.loc);
       }
       case "TokenSelf":
-        return makeSelf(tok.loc);
+        return ast.makeSelf(tok.loc);
       case "TokenSuper": {
         const next = p.pop();
         let index: ast.Node | null = null;
@@ -1276,7 +924,7 @@ class parser {
             if (error.isStaticError(fieldID)) {
               return fieldID;
             }
-            id = makeIdentifier(fieldID.data, fieldID.loc);
+            id = ast.makeIdentifier(fieldID.data, fieldID.loc);
             break;
           }
           case "TokenBracketL": {
@@ -1296,7 +944,7 @@ class parser {
           return error.MakeStaticError(
             "Expected . or [ after super.", tok.loc);
         }
-        return makeSuperIndex(index, id, tok.loc);
+        return ast.makeSuperIndex(index, id, tok.loc);
       }
     }
 
@@ -1354,7 +1002,7 @@ class parser {
         if (error.isStaticError(rest)) {
           return rest;
         }
-        return makeAssert(cond, msg, rest, locFromTokenAST(begin, rest));
+        return ast.makeAssert(cond, msg, rest, locFromTokenAST(begin, rest));
       }
 
       case "TokenError": {
@@ -1363,7 +1011,7 @@ class parser {
         if (error.isStaticError(expr)) {
           return expr;
         }
-        return makeError(expr, locFromTokenAST(begin, expr));
+        return ast.makeError(expr, locFromTokenAST(begin, expr));
       }
 
       case "TokenIf": {
@@ -1390,7 +1038,7 @@ class parser {
           }
           lr = locFromTokenAST(begin, branchFalse)
         }
-        return makeConditional(cond, branchTrue, branchFalse, lr);
+        return ast.makeConditional(cond, branchTrue, branchFalse, lr);
       }
 
       case "TokenFunction": {
@@ -1431,7 +1079,7 @@ class parser {
           return body;
         }
         if (ast.isLiteralString(body)) {
-          return makeImport(body.value, locFromTokenAST(begin, body));
+          return ast.makeImport(body.value, locFromTokenAST(begin, body));
         }
         return error.MakeStaticError(
           "Computed imports are not allowed", body.loc);
@@ -1444,7 +1092,7 @@ class parser {
           return body;
         }
         if (ast.isLiteralString(body)) {
-          return makeImportStr(body.value, locFromTokenAST(begin, body));
+          return ast.makeImportStr(body.value, locFromTokenAST(begin, body));
         }
         return error.MakeStaticError(
           "Computed imports are not allowed", body.loc);
@@ -1472,7 +1120,7 @@ class parser {
         if (error.isStaticError(body)) {
           return body;
         }
-        return makeLocal(binds, body, locFromTokenAST(begin, body));
+        return ast.makeLocal(binds, body, locFromTokenAST(begin, body));
       }
 
       default: {
@@ -1489,7 +1137,7 @@ class parser {
             if (error.isStaticError(expr)) {
               return expr;
             }
-            return makeUnary(uop, expr, locFromTokenAST(op, expr));
+            return ast.makeUnary(uop, expr, locFromTokenAST(op, expr));
           }
         }
 
@@ -1559,7 +1207,7 @@ class parser {
                 return end;
               }
 
-              lhs = makeIndex(lhs, index, null, locFromTokens(begin, end));
+              lhs = ast.makeIndex(lhs, index, null, locFromTokens(begin, end));
               break;
             }
             case "TokenDot": {
@@ -1567,8 +1215,8 @@ class parser {
               if (error.isStaticError(fieldID)) {
                 return fieldID;
               }
-              const id = makeIdentifier(fieldID.data, fieldID.loc);
-              lhs = makeIndex(lhs, null, id, locFromTokens(begin, fieldID));
+              const id = ast.makeIdentifier(fieldID.data, fieldID.loc);
+              lhs = ast.makeIndex(lhs, null, id, locFromTokens(begin, fieldID));
               break;
             }
             case "TokenParenL": {
@@ -1584,7 +1232,7 @@ class parser {
                 p.pop();
                 tailStrict = true;
               }
-              lhs = makeApply(
+              lhs = ast.makeApply(
                 lhs, args, gotComma, tailStrict, locFromTokens(begin, end));
               break;
             }
@@ -1593,7 +1241,7 @@ class parser {
               if (error.isStaticError(result)) {
                 return result;
               }
-              lhs = makeApplyBrace(
+              lhs = ast.makeApplyBrace(
                 lhs, result.objRemainder, locFromTokens(begin, result.next));
               break;
             }
@@ -1605,7 +1253,7 @@ class parser {
               if (bop == null) {
                 throw new Error("INTERNAL ERROR: `parse` can't return a null node unless an `error` is populated");
               }
-              lhs = makeBinary(lhs, bop, rhs, locFromTokenAST(begin, rhs));
+              lhs = ast.makeBinary(lhs, bop, rhs, locFromTokenAST(begin, rhs));
               break;
             }
           }
@@ -1635,7 +1283,5 @@ export const Parse = (
     return error.MakeStaticError(`Did not expect: ${p.peek()}`, p.peek().loc);
   }
 
-  // TODO: Don't cast me bro.
-  return <ast.Node>expr;
+  return expr;
 }
-

--- a/server/parser/parser.ts
+++ b/server/parser/parser.ts
@@ -521,12 +521,12 @@ class parser {
 
     let ids = im.List<ast.IdentifierName>();
     for (let n of result.exprs.toArray()) {
-      if (n.type != "VarNode") {
+      if (!ast.isVar(n)) {
         return error.MakeStaticError(
           `Expected simple identifier but got a complex expression.`,
           n.loc);
       }
-      ids = ids.push((<ast.Var>n).id.name);
+      ids = ids.push(n.id.name);
     }
     return {ids: ids, gotComma: result.gotComma};
   };
@@ -1430,9 +1430,8 @@ class parser {
         if (error.isStaticError(body)) {
           return body;
         }
-        if (body.type === "LiteralStringNode") {
-          const lit = <ast.LiteralString>body;
-          return makeImport(lit.value, locFromTokenAST(begin, body));
+        if (ast.isLiteralString(body)) {
+          return makeImport(body.value, locFromTokenAST(begin, body));
         }
         return error.MakeStaticError(
           "Computed imports are not allowed", body.loc);
@@ -1444,9 +1443,8 @@ class parser {
         if (error.isStaticError(body)) {
           return body;
         }
-        if (body.type === "LiteralStringNode") {
-          const lit = <ast.LiteralString>body;
-          return makeImportStr(lit.value, locFromTokenAST(begin, body));
+        if (ast.isLiteralString(body)) {
+          return makeImportStr(body.value, locFromTokenAST(begin, body));
         }
         return error.MakeStaticError(
           "Computed imports are not allowed", body.loc);

--- a/server/parser/parser.ts
+++ b/server/parser/parser.ts
@@ -985,7 +985,9 @@ class parser {
       this.pop();
 
       // Get the CPP comment block
-      heading = im.List<ast.Comment>(ast.MakeCppComment(begin.loc, begin.data))
+      heading = im.List<ast.Comment>([
+        ast.MakeCppComment(begin.loc, begin.data)
+      ]);
       while (true) {
         begin = this.peek();
         if (begin.kind === "TokenCommentCpp") {

--- a/server/parser/parser.ts
+++ b/server/parser/parser.ts
@@ -747,11 +747,8 @@ class parser {
       if (error.isStaticError(arr)) {
         return arr;
       }
-      specs = specs.push({
-        kind:    "CompFor",
-        varName: id,
-        expr:    arr,
-      });
+      specs = specs.push(ast.makeCompSpec(
+        "CompFor", id, arr, locFromTokenAST(varID, arr)));
 
       let maybeIf = this.pop();
       for (; maybeIf.kind === "TokenIf"; maybeIf = this.pop()) {
@@ -759,11 +756,8 @@ class parser {
         if (error.isStaticError(cond)) {
           return cond;
         }
-        specs = specs.push({
-          kind:    "CompIf",
-          varName: null,
-          expr:    cond,
-        });
+        specs = specs.push(ast.makeCompSpec(
+          "CompIf", null, cond, locFromTokenAST(maybeIf, cond)));
       }
       if (maybeIf.kind === end) {
         return {compSpecs: specs, maybeIf: maybeIf};

--- a/test/data/simple-import.jsonnet
+++ b/test/data/simple-import.jsonnet
@@ -3,5 +3,6 @@ local fooModule = import "./simple-import.libsonnet";
 {
   bar: fooModule,
   baz: fooModule.foo,
-  bat: fooModule.bar
+  bat: fooModule.bar,
+  bag: fooModule.baz.bat,
 }

--- a/test/data/simple-import.libsonnet
+++ b/test/data/simple-import.libsonnet
@@ -3,5 +3,9 @@
   foo: 99,
   // `bar` is a local, and comments on top of it should not be
   // retrieved.
-  local bar = 300
+  local bar = 300,
+  baz: {
+    // `bat` contains a fancy value, `batVal`.
+    bat: "batVal",
+  },
 }

--- a/test/data/simple-import.libsonnet
+++ b/test/data/simple-import.libsonnet
@@ -1,3 +1,4 @@
+local f = "fakeImport";
 {
   // `foo` is a property that has very useful data.
   foo: 99,

--- a/test/data/simple-nodes.jsonnet
+++ b/test/data/simple-nodes.jsonnet
@@ -13,4 +13,7 @@
   local nestedMerge2 = {merged2: merged2},
   local nestedMerge3 = nestedMerge1.merged1 + nestedMerge2.merged2,
   useMerged2: nestedMerge3.a,
+  local numberVal1 = 1,
+  local numberVal2 = numberVal1,
+  number: numberVal2,
 }

--- a/test/data/simple-nodes.jsonnet
+++ b/test/data/simple-nodes.jsonnet
@@ -4,4 +4,13 @@
   local foo = 3,
   local baz = bar.baz,
   local bar = {baz: 3},
+  local merged1 = {a: 1, b: 2} + {b: 3, c: 4},
+  local merged2 = merged1 + {a: 99},
+  local merged3 = {a: 99} + merged1,
+  local merged4 = merged1 + merged2,
+  useMerged: [merged1.b, merged2.a, merged3.a, merged4.a],
+  local nestedMerge1 = {merged1: merged1},
+  local nestedMerge2 = {merged2: merged2},
+  local nestedMerge3 = nestedMerge1.merged1 + nestedMerge2.merged2,
+  useMerged2: nestedMerge3.a,
 }

--- a/test/data/simple-nodes.jsonnet
+++ b/test/data/simple-nodes.jsonnet
@@ -2,4 +2,6 @@
   property1: foo,
   property2: 2,
   local foo = 3,
+  local baz = bar.baz,
+  local bar = {baz: 3},
 }

--- a/test/server/analysis_tests.ts
+++ b/test/server/analysis_tests.ts
@@ -231,6 +231,23 @@ describe("Searching an AST by position", () => {
       assert.equal(resolved.originalString, "99");
     }
   });
+
+  it("Can resolve identifiers that point to identifiers", () => {
+    // Regression test. Tests that we can resolve a variable that
+    // points to another variable. In this case, `numberVal2` refers
+    // to `numberVal1`.
+
+    const node = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+      rootNode, makeLocation(18, 19));
+    assert.isNotNull(node);
+    assert.equal(node.type, "IdentifierNode");
+    assert.equal(node.name, "numberVal2");
+
+    const resolved = <ast.LiteralNumber>analyzer.resolveIdentifier(node);
+    assert.isNotNull(resolved);
+    assert.equal(resolved.type, "LiteralNumberNode");
+    assert.equal(resolved.originalString, "1");
+  });
 });
 
 describe("Imported symbol resolution", () => {

--- a/test/server/analysis_tests.ts
+++ b/test/server/analysis_tests.ts
@@ -159,6 +159,78 @@ describe("Searching an AST by position", () => {
     assert.equal(resolved.type, "LiteralNumberNode");
     assert.equal(resolved.originalString, "3");
   });
+
+  it("Can resolve identifiers that refer to mixins", () => {
+    // merged1.b
+    {
+      const merged1 = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+        rootNode, makeLocation(11, 23));
+      assert.isNotNull(merged1);
+      assert.equal(merged1.type, "IdentifierNode");
+      assert.equal(merged1.name, "b");
+
+      const resolved = <ast.LiteralNumber>analyzer.resolveIdentifier(merged1);
+      assert.isNotNull(resolved);
+      assert.equal(resolved.type, "LiteralNumberNode");
+      assert.equal(resolved.originalString, "3");
+    }
+
+    // merged2.a
+    {
+      const merged2 = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+        rootNode, makeLocation(11, 34));
+      assert.isNotNull(merged2);
+      assert.equal(merged2.type, "IdentifierNode");
+      assert.equal(merged2.name, "a");
+
+      const resolved = <ast.LiteralNumber>analyzer.resolveIdentifier(merged2);
+      assert.isNotNull(resolved);
+      assert.equal(resolved.type, "LiteralNumberNode");
+      assert.equal(resolved.originalString, "99");
+    }
+
+    // merged3.a
+    {
+      const merged3 = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+        rootNode, makeLocation(11, 45));
+      assert.isNotNull(merged3);
+      assert.equal(merged3.type, "IdentifierNode");
+      assert.equal(merged3.name, "a");
+
+      const resolved = <ast.LiteralNumber>analyzer.resolveIdentifier(merged3);
+      assert.isNotNull(resolved);
+      assert.equal(resolved.type, "LiteralNumberNode");
+      assert.equal(resolved.originalString, "1");
+    }
+
+    // merged4.a
+    {
+      const merged4 = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+        rootNode, makeLocation(11, 56));
+      assert.isNotNull(merged4);
+      assert.equal(merged4.type, "IdentifierNode");
+      assert.equal(merged4.name, "a");
+
+      const resolved = <ast.LiteralNumber>analyzer.resolveIdentifier(merged4);
+      assert.isNotNull(resolved);
+      assert.equal(resolved.type, "LiteralNumberNode");
+      assert.equal(resolved.originalString, "99");
+    }
+
+    // merged4.a
+    {
+      const merged5 = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+        rootNode, makeLocation(15, 28));
+      assert.isNotNull(merged5);
+      assert.equal(merged5.type, "IdentifierNode");
+      assert.equal(merged5.name, "a");
+
+      const resolved = <ast.LiteralNumber>analyzer.resolveIdentifier(merged5);
+      assert.isNotNull(resolved);
+      assert.equal(resolved.type, "LiteralNumberNode");
+      assert.equal(resolved.originalString, "99");
+    }
+  });
 });
 
 describe("Imported symbol resolution", () => {

--- a/test/server/analysis_tests.ts
+++ b/test/server/analysis_tests.ts
@@ -172,13 +172,12 @@ describe("Imported symbol resolution", () => {
 
   it("Can dereference the object that is imported", () => {
     const importedSymbol =
-      <ast.ObjectNode>analyzer.resolveSymbolAtPositionFromAst(
+      <ast.Local>analyzer.resolveSymbolAtPositionFromAst(
         rootNode, makeLocation(4, 8));
     assert.isNotNull(importedSymbol);
-    assert.equal(importedSymbol.type, "ObjectNode");
+    assert.equal(importedSymbol.type, "LocalNode");
     assert.isNull(importedSymbol.parent);
-    assert.equal(importedSymbol.headingComments.count(), 0);
-    assertLocationRange(importedSymbol.loc, 1, 1, 11, 2);
+    assertLocationRange(importedSymbol.loc, 1, 1, 12, 2);
   });
 
   it("Can dereference fields from an imported module", () => {
@@ -192,7 +191,7 @@ describe("Imported symbol resolution", () => {
     assert.isNotNull(valueofObjectField);
     assert.equal(valueofObjectField.type, "LiteralNumberNode");
     assert.equal(valueofObjectField.originalString, "99");
-    assertLocationRange(valueofObjectField.loc, 3, 8, 3, 10);
+    assertLocationRange(valueofObjectField.loc, 4, 8, 4, 10);
   });
 
   it("Can find comments for a field in an imported module", () => {

--- a/test/server/analysis_tests.ts
+++ b/test/server/analysis_tests.ts
@@ -57,6 +57,7 @@ describe("Searching an AST by position", () => {
     {
       const property1Id = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
         rootNode, makeLocation(2, 5));
+      assert.isNotNull(property1Id);
       assert.equal(property1Id.type, "IdentifierNode");
       assert.equal(property1Id.name, "property1");
       assert.isNotNull(property1Id.parent);
@@ -72,6 +73,7 @@ describe("Searching an AST by position", () => {
     {
       const target1Id = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
         rootNode, makeLocation(2, 14));
+      assert.isNotNull(target1Id);
       assert.equal(target1Id.type, "IdentifierNode");
       assert.equal(target1Id.name, "foo");
       assert.isNotNull(target1Id.parent);
@@ -94,6 +96,7 @@ describe("Searching an AST by position", () => {
 
     const target2Id = <ast.LiteralNumber>analyzer.getNodeAtPositionFromAst(
       rootNode, makeLocation(3, 15));
+    assert.isNotNull(target2Id);
     assert.equal(target2Id.type, "LiteralNumberNode");
     assert.equal(target2Id.originalString, "2");
     assert.isNotNull(target2Id.parent);
@@ -110,6 +113,7 @@ describe("Searching an AST by position", () => {
     {
       const property3Id = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
         rootNode, makeLocation(4, 9));
+      assert.isNotNull(property3Id);
       assert.equal(property3Id.type, "IdentifierNode");
       assert.equal(property3Id.name, "foo");
       assert.isNotNull(property3Id.parent);
@@ -125,6 +129,7 @@ describe("Searching an AST by position", () => {
     {
       const target3Id = <ast.LiteralNumber>analyzer.getNodeAtPositionFromAst(
         rootNode, makeLocation(4, 15));
+      assert.isNotNull(target3Id);
       assert.equal(target3Id.type, "LiteralNumberNode");
       assert.equal(target3Id.originalString, "3");
       assert.isNotNull(target3Id.parent);
@@ -135,6 +140,24 @@ describe("Searching an AST by position", () => {
       assert.equal(target3Parent.kind, "ObjectLocal");
       assertLocationRange(target3Parent.loc, 4, 3, 4, 16);
     }
+  });
+
+  it("Resolution of `local` object fields is order-independent", () => {
+    // This location points at the `baz` symbol in the expression
+    // `bar.baz`, where `bar` is a `local` field that's declared below
+    // the current field. This tests that we correctly resolve that
+    // reference, even though it occurs after the current object
+    // field.
+    const property4Id = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+      rootNode, makeLocation(5, 20));
+    assert.isNotNull(property4Id);
+    assert.equal(property4Id.type, "IdentifierNode");
+    assert.equal(property4Id.name, "baz");
+
+    const resolved = <ast.LiteralNumber>analyzer.resolveIdentifier(property4Id);
+    assert.isNotNull(resolved);
+    assert.equal(resolved.type, "LiteralNumberNode");
+    assert.equal(resolved.originalString, "3");
   });
 });
 
@@ -151,6 +174,7 @@ describe("Imported symbol resolution", () => {
     const importedSymbol =
       <ast.ObjectNode>analyzer.resolveSymbolAtPositionFromAst(
         rootNode, makeLocation(4, 8));
+    assert.isNotNull(importedSymbol);
     assert.equal(importedSymbol.type, "ObjectNode");
     assert.isNull(importedSymbol.parent);
     assert.equal(importedSymbol.headingComments.count(), 0);
@@ -165,6 +189,7 @@ describe("Imported symbol resolution", () => {
     const valueofObjectField =
       <ast.LiteralNumber>analyzer.resolveSymbolAtPositionFromAst(
         rootNode, makeLocation(5, 19));
+    assert.isNotNull(valueofObjectField);
     assert.equal(valueofObjectField.type, "LiteralNumberNode");
     assert.equal(valueofObjectField.originalString, "99");
     assertLocationRange(valueofObjectField.loc, 3, 8, 3, 10);

--- a/test/server/analysis_tests.ts
+++ b/test/server/analysis_tests.ts
@@ -154,7 +154,7 @@ describe("Imported symbol resolution", () => {
     assert.equal(importedSymbol.type, "ObjectNode");
     assert.isNull(importedSymbol.parent);
     assert.equal(importedSymbol.headingComments.count(), 0);
-    assertLocationRange(importedSymbol.loc, 1, 1, 7, 2);
+    assertLocationRange(importedSymbol.loc, 1, 1, 11, 2);
   });
 
   it("Can dereference fields from an imported module", () => {
@@ -183,6 +183,23 @@ describe("Imported symbol resolution", () => {
     assert.isNotNull(comments);
     assert.equal(
       comments, " `foo` is a property that has very useful data.");
+  });
+
+  it("Can find comments for a nested field in an imported module", () => {
+    // This location points at the `bat` symbol in the expression
+    // `fooModule.baz.bat`, where `fooModule` is an imported module.
+    // This tests that we can correctly obtain the documentation for
+    // a symbol that lies in a multiply-nested index node.
+    const valueOfObjectField =
+      <ast.LiteralString>analyzer.resolveSymbolAtPositionFromAst(
+        rootNode, makeLocation(7, 23));
+    assert.isNotNull(valueOfObjectField);
+    assert.equal(valueOfObjectField.type, "LiteralStringNode");
+    assert.equal(valueOfObjectField.value, "batVal");
+
+    const comments = analyzer.resolveComments(valueOfObjectField);
+    assert.isNotNull(comments);
+    assert.equal(comments, " `bat` contains a fancy value, `batVal`.");
   });
 
   it("Cannot find comments for `local` field in an imported module", () => {

--- a/test/server/ast/parser_tests.ts
+++ b/test/server/ast/parser_tests.ts
@@ -85,9 +85,6 @@ const tests = [
 describe("Successfully parsing text", () => {
   for (let s of tests) {
     it(`${JSON.stringify(s)}`, () => {
-      if (JSON.stringify(s) === "\"true || false\"") {
-        const s = 3;
-      }
       const tokens = lexer.Lex("test", s);
       if (error.isStaticError(tokens)) {
         throw new Error(`Unexpected lexer to emit tokens\n  input: ${s}`);

--- a/test/server/ast/parser_tests.ts
+++ b/test/server/ast/parser_tests.ts
@@ -25,6 +25,7 @@ const tests = [
 \n|||",
 
   `foo(bar)`,
+  `foo(bar=99)`,
   `foo(bar) tailstrict`,
   `foo.bar`,
   `foo[bar]`,
@@ -35,10 +36,13 @@ const tests = [
 
   `local foo = "bar"; foo`,
   `local foo(bar) = bar; foo(1)`,
+  `local foo(bar=4) = bar; foo(1)`,
   `{ local foo = "bar", baz: 1}`,
   `{ local foo(bar) = bar, baz: foo(1)}`,
+  `{ local foo(bar=[1]) = bar, baz: foo(1)}`,
 
   `{ foo(bar, baz): bar+baz }`,
+  `{ foo(bar={a:1}):: bar }`,
 
   `{ ["foo" + "bar"]: 3 }`,
   `{ ["field" + x]: x for x in [1, 2, 3] }`,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,12 @@
 {
     "compilerOptions": {
         "strictNullChecks": true,
+        "noFallthroughCasesInSwitch": true,
+        "alwaysStrict": true,
+        "forceConsistentCasingInFileNames": true,
+        "pretty": true,
+        "noImplicitThis": false,
+        "noImplicitReturns": true,
         "module": "commonjs",
         "target": "es6",
         "outDir": "out",


### PR DESCRIPTION
This series of commits will begin the process of hardening up the analysis code base, as well as greatly improving the `Analyzer`'s ability to statically resolve symbols.

The former involves changes such as fully implementing the `Visitor`, re-organizing the `Node` class hierarchy, polishing the tooltips that are emitted when a user hovers over a symbol, and moving code to places that make more sense (such as moving the pretty-printing to the `Node` class hierarchy).

The latter largely involves adding support for resolving symbols that are defined as part of many Jsonnet constructs (such as function parameters, symbols in imports with static mixins, and so on).