### PR TITLE
Improve AST searching and symbol resolution primitives

### DIFF
--- a/server/ast/analyzer.ts
+++ b/server/ast/analyzer.ts
@@ -52,6 +52,9 @@ export class Analyzer implements EventedAnalyzer {
 
     // Get symbol we're hovering over.
     const nodeAtPos = this.getNodeAtPosition(fileUri, cursorLoc);
+    if (astVisitor.isFindFailure(nodeAtPos)) {
+      return Promise.resolve().then(() => {return {contents:[]}});
+    }
     if (nodeAtPos.parent != null && ast.isFunctionParam(nodeAtPos.parent)) {
       // A function parameter is a free variable, so we can't resolve
       // it. Simply return.
@@ -123,8 +126,15 @@ export class Analyzer implements EventedAnalyzer {
               return [];
             }
 
-            const nodeAtPos = this.getNodeAtPositionFromAst(
+            let nodeAtPos = this.getNodeAtPositionFromAst(
               lastParse.parse, cursorLoc);
+            if (astVisitor.isAnalyzableFindFailure(nodeAtPos)) {
+              nodeAtPos = nodeAtPos.tightestEnclosingNode;
+            } else if (astVisitor.isUnanalyzableFindFailure(nodeAtPos)) {
+              // TODO(hausdorff): Revisit this when we revamp the
+              // `onComplete` abstractions.
+              return [];
+            }
 
             const rest = parse.parse.parseError.rest;
 
@@ -135,42 +145,56 @@ export class Analyzer implements EventedAnalyzer {
               : <ast.Environment>nodeAtPos.env;
             new astVisitor.InitializingVisitor(rest, nodeAtPos, env).visit();
 
-            const resolved = ast.resolveIndirections(
+            const resolved = ast.tryResolveIndirections(
               rest, this.compilerService, this.documents);
-            if (resolved == null) {
-              if (ast.isVar(rest)) {
-                return this.completionsFromIdentifier(rest.id);
-              }
-              return [];
-            } else {
+            if (ast.isIndexedObjectFields(resolved)) {
               return this.completableFields(resolved);
+            } else if (ast.isResolveFailure(resolved) && ast.isVar(rest)) {
+              return this.completionsFromIdentifier(rest.id);
             }
+            return [];
           } else if (c === ".") {
             const lastParse = this.compilerService.getLastSuccess(fileUri);
             if (lastParse == null) {
               return [];
             }
-            const nodeAtPos = this.getNodeAtPositionFromAst(
+            let nodeAtPos = this.getNodeAtPositionFromAst(
               lastParse.parse, cursorLoc);
-
-            const resolved = ast.resolveIndirections(
-              nodeAtPos, this.compilerService, this.documents);
-            if (resolved == null) {
+            if (astVisitor.isAnalyzableFindFailure(nodeAtPos)) {
+              nodeAtPos = nodeAtPos.tightestEnclosingNode;
+            } else if (astVisitor.isUnanalyzableFindFailure(nodeAtPos)) {
+              // TODO(hausdorff): Revisit this when we revamp the
+              // `onComplete` abstractions.
               return [];
             }
 
-            return this.completableFields(resolved);
+            const resolved = ast.tryResolveIndirections(
+              nodeAtPos, this.compilerService, this.documents);
+            if (ast.isIndexedObjectFields(resolved)) {
+              return this.completableFields(resolved)
+            }
+            return [];
           } else {
-            const nodeAtPos = this.getNodeAtPositionFromAst(
+            let nodeAtPos = this.getNodeAtPositionFromAst(
               parse.parse, cursorLoc);
+            if (astVisitor.isAnalyzableFindFailure(nodeAtPos)) {
+              nodeAtPos = nodeAtPos.tightestEnclosingNode;
+            } else if (astVisitor.isUnanalyzableFindFailure(nodeAtPos)) {
+              // TODO(hausdorff): Revisit this when we revamp the
+              // `onComplete` abstractions.
+              return [];
+            }
 
             if (!ast.isIdentifier(nodeAtPos)) {
               // Attempt to resolve the node.
-              const resolved = ast.resolveIndirections(
+              const resolved = ast.tryResolveIndirections(
                 nodeAtPos, this.compilerService, this.documents);
-              if (resolved != null) {
+              if (ast.isIndexedObjectFields(resolved)) {
                 return this.completableFields(resolved);
               }
+              // TODO(hausdorff): Revisit this when we revamp the
+              // `onComplete` abstractions.
+               return [];
             }
 
             // Fallback on completing the identifier.
@@ -241,16 +265,17 @@ export class Analyzer implements EventedAnalyzer {
       return node.env && envToSuggestions(node.env) || [];
     }
 
-    let resolved: ast.Node | null = null;
+    let resolved: ast.Node | ast.IndexedObjectFields | ast.ResolveFailure =
+      ast.Unresolved.Instance;
     if (ast.isIndex(parent)) {
-      resolved = ast.resolveIndirections(
+      resolved = ast.tryResolveIndirections(
         parent.target, this.compilerService, this.documents);
     } else {
-      resolved = ast.resolveIndirections(
+      resolved = ast.tryResolveIndirections(
         parent, this.compilerService, this.documents);
     }
 
-    if (resolved != null) {
+    if (ast.isIndexedObjectFields(resolved)) {
       return this.completableFields(resolved);
     }
 
@@ -259,21 +284,14 @@ export class Analyzer implements EventedAnalyzer {
   }
 
   private completableFields = (
-    resolved: ast.Node
+    fieldSet: ast.IndexedObjectFields
   ): service.CompletionInfo[] => {
     // Attempt to get all the possible fields we could suggest. If the
     // resolved item is an `ObjectNode`, just use its fields; if it's
     // a mixin of two objects, merge them and use the merged fields
     // instead.
-    const fieldSet = ast.isFieldsResolvable(resolved)
-      ? resolved.resolveFields(this.compilerService, this.documents)
-      : immutable.Map<string, ast.ObjectField>();
 
-    const fields = fieldSet == null
-      ? immutable.List()
-      : immutable.List(fieldSet.values())
-
-    return fields
+    return immutable.List(fieldSet.values())
       .filter((field: ast.ObjectField) =>
         field != null && field.id != null && field.expr2 != null && field.kind !== "ObjectLocal")
       .map((field: ast.ObjectField) => {
@@ -304,14 +322,24 @@ export class Analyzer implements EventedAnalyzer {
   public resolveSymbolAtPosition = (
     fileUri: string, pos: error.Location,
   ): ast.Node | null => {
-    const nodeAtPos = this.getNodeAtPosition(fileUri, pos);
+    let nodeAtPos = this.getNodeAtPosition(fileUri, pos);
+    if (astVisitor.isAnalyzableFindFailure(nodeAtPos)) {
+      nodeAtPos = nodeAtPos.tightestEnclosingNode;
+    } else if (astVisitor.isUnanalyzableFindFailure(nodeAtPos)) {
+      return null;
+    }
     return this.resolveSymbol(nodeAtPos);
   }
 
   public resolveSymbolAtPositionFromAst = (
     rootNode: ast.Node, pos: error.Location,
   ): ast.Node | null => {
-    const nodeAtPos = this.getNodeAtPositionFromAst(rootNode, pos);
+    let nodeAtPos = this.getNodeAtPositionFromAst(rootNode, pos);
+    if (astVisitor.isAnalyzableFindFailure(nodeAtPos)) {
+      nodeAtPos = nodeAtPos.tightestEnclosingNode;
+    } else if (astVisitor.isUnanalyzableFindFailure(nodeAtPos)) {
+      return null;
+    }
     return this.resolveSymbol(nodeAtPos);
   }
 
@@ -344,18 +372,18 @@ export class Analyzer implements EventedAnalyzer {
   }
 
   private resolveSymbol = (node: ast.Node): ast.Node | null => {
-    if (node == null ) {
-      return null;
-    }
-
     if (node.parent && ast.isObjectField(node.parent)) {
       return node.parent;
     }
 
     switch(node.type) {
       case "IdentifierNode": {
-        return (<ast.Identifier>node).resolve(
+        const resolved = (<ast.Identifier>node).resolve(
           this.compilerService, this.documents);
+        if (ast.isIndexedObjectFields(resolved) || ast.isResolveFailure(resolved)) {
+          return null;
+        }
+        return resolved;
       }
       case "LocalNode": {
         return node;
@@ -390,7 +418,7 @@ export class Analyzer implements EventedAnalyzer {
 
   public getNodeAtPosition = (
     fileUri: string, pos: error.Location,
-  ): ast.Node => {
+  ): ast.Node | astVisitor.FindFailure => {
     const {text: docText, version: version} = this.documents.get(fileUri);
     const cached = this.compilerService.cache(fileUri, docText, version);
     if (compiler.isFailedParsedDocument(cached)) {
@@ -407,7 +435,7 @@ export class Analyzer implements EventedAnalyzer {
 
   public getNodeAtPositionFromAst = (
     rootNode: ast.Node, pos: error.Location
-  ): ast.Node => {
+  ): ast.Node | astVisitor.FindFailure => {
     // Special case. Make sure that if the cursor is beyond the range
     // of text of the last good parse, we just return the last node.
     // For example, if the user types a `.` character at the end of
@@ -420,7 +448,8 @@ export class Analyzer implements EventedAnalyzer {
 
     const visitor = new astVisitor.CursorVisitor(pos, rootNode);
     visitor.visit();
-    return visitor.NodeAtPosition;
+    const tightestNode = visitor.nodeAtPosition;
+    return tightestNode;
   }
 }
 

--- a/server/ast/visitor.ts
+++ b/server/ast/visitor.ts
@@ -7,158 +7,132 @@ import * as error from '../lexer/static_error';
 import * as lexer from '../lexer/lexer';
 
 export interface Visitor {
-  Visit(node: ast.Node, parent: ast.Node | null, currEnv: ast.Environment): void
-  VisitComment(node: ast.Comment): void
-  VisitCompSpec(node: ast.CompSpec): void
-  VisitApply(node: ast.Apply): void
-  VisitApplyBrace(node: ast.ApplyBrace): void
-  VisitApplyParamAssignmentNode(node: ast.ApplyParamAssignment): void
-  VisitArray(node: ast.Array): void
-  VisitArrayComp(node: ast.ArrayComp): void
-  VisitAssert(node: ast.Assert): void
-  VisitBinary(node: ast.Binary): void
-  VisitBuiltin(node: ast.Builtin): void
-  VisitConditional(node: ast.Conditional): void
-  VisitDollar(node: ast.Dollar): void
-  VisitError(node: ast.ErrorNode): void
-  VisitFunction(node: ast.Function): void
-  VisitIdentifier(node: ast.Identifier): void
-  VisitImport(node: ast.Import): void
-  VisitImportStr(node: ast.ImportStr): void
-  VisitIndex(node: ast.Index): void
-  // // VisitLocalBind(node: ast.LocalBind): void
-  VisitLocal(node: ast.Local): void
-  VisitLiteralBoolean(node: ast.LiteralBoolean): void
-  VisitLiteralNull(node: ast.LiteralNull): void
-  VisitLiteralNumber(node: ast.LiteralNumber): void
-  VisitLiteralString(node: ast.LiteralString): void
-  VisitObjectField(node: ast.ObjectField): void
-  VisitObject(node: ast.ObjectNode): void
-  VisitDesugaredObjectField(node: ast.DesugaredObjectField): void
-  VisitDesugaredObject(node: ast.DesugaredObject): void
-  VisitObjectComp(node: ast.ObjectComp): void
-  VisitObjectComprehensionSimple(node: ast.ObjectComprehensionSimple): void
-  VisitSelf(node: ast.Self): void
-  VisitSuperIndex(node: ast.SuperIndex): void
-  VisitUnary(node: ast.Unary): void
-  VisitVar(node: ast.Var): void
+  visit(): void
 }
 
 export abstract class VisitorBase implements Visitor {
-  private rootObject: ast.Node | null = null;
+  protected rootObject: ast.Node | null = null;
 
-  public Visit = (
+  constructor(
+    private rootNode: ast.Node,
+    private parent: ast.Node | null = null,
+    private env: ast.Environment = ast.emptyEnvironment,
+  ) {}
+
+  public visit = () => {
+    this.visitHelper(this.rootNode, null, this.env);
+  }
+
+  protected visitHelper = (
     node: ast.Node, parent: ast.Node | null, currEnv: ast.Environment
   ): void => {
     if (node == null) {
-      throw Error("Can't visit a null node");
+      throw Error("INTERNAL ERROR: Can't visit a null node");
     }
 
-    node.parent = parent;
-    node.env = currEnv;
-    node.rootObject = this.rootObject;
+    this.onPrevisit(node, parent, currEnv);
 
     switch(node.type) {
       case "CommentNode": {
-        this.VisitComment(<ast.Comment>node);
+        this.visitComment(<ast.Comment>node);
         return;
       }
       case "CompSpecNode": {
         const castedNode = <ast.CompSpec>node;
-        this.VisitCompSpec(castedNode);
-        castedNode.varName && this.Visit(castedNode.varName, castedNode, currEnv);
-        this.Visit(castedNode.expr, castedNode, currEnv);
+        this.visitCompSpec(castedNode);
+        castedNode.varName && this.visitHelper(castedNode.varName, castedNode, currEnv);
+        this.visitHelper(castedNode.expr, castedNode, currEnv);
         return;
       }
       case "ApplyNode": {
         const castedNode = <ast.Apply>node;
-        this.VisitApply(castedNode);
-        this.Visit(castedNode.target, castedNode, currEnv);
+        this.visitApply(castedNode);
+        this.visitHelper(castedNode.target, castedNode, currEnv);
         castedNode.args.forEach((arg: ast.Node) => {
-          this.Visit(arg, castedNode, currEnv);
+          this.visitHelper(arg, castedNode, currEnv);
         });
         return;
       }
       case "ApplyBraceNode": {
         const castedNode = <ast.ApplyBrace>node;
-        this.VisitApplyBrace(castedNode);
-        this.Visit(castedNode.left, castedNode, currEnv);
-        this.Visit(castedNode.right, castedNode, currEnv);
+        this.visitApplyBrace(castedNode);
+        this.visitHelper(castedNode.left, castedNode, currEnv);
+        this.visitHelper(castedNode.right, castedNode, currEnv);
         return;
       }
       case "ApplyParamAssignmentNode": {
         const castedNode = <ast.ApplyParamAssignment>node;
-        this.VisitApplyParamAssignmentNode(castedNode);
-        this.Visit(castedNode.right, castedNode, currEnv);
+        this.visitApplyParamAssignmentNode(castedNode);
+        this.visitHelper(castedNode.right, castedNode, currEnv);
         return;
       }
       case "ArrayNode": {
         const castedNode = <ast.Array>node;
-        this.VisitArray(castedNode);
-        castedNode.headingComment && this.Visit(
+        this.visitArray(castedNode);
+        castedNode.headingComment && this.visitHelper(
           castedNode.headingComment, castedNode, currEnv);
         castedNode.elements.forEach((e: ast.Node) => {
-          this.Visit(e, castedNode, currEnv);
+          this.visitHelper(e, castedNode, currEnv);
         });
-        castedNode.trailingComment && this.Visit(
+        castedNode.trailingComment && this.visitHelper(
           castedNode.trailingComment, castedNode, currEnv);
         return;
       }
       case "ArrayCompNode": {
         const castedNode = <ast.ArrayComp>node;
-        this.VisitArrayComp(castedNode);
-        this.Visit(castedNode.body, castedNode, currEnv);
+        this.visitArrayComp(castedNode);
+        this.visitHelper(castedNode.body, castedNode, currEnv);
         castedNode.specs.forEach((spec: ast.CompSpec) =>
-          this.Visit(spec, castedNode, currEnv));
+          this.visitHelper(spec, castedNode, currEnv));
         return;
       }
       case "AssertNode": {
         const castedNode = <ast.Assert>node;
-        this.VisitAssert(castedNode);
-        this.Visit(castedNode.cond, castedNode, currEnv);
-        castedNode.message && this.Visit(
+        this.visitAssert(castedNode);
+        this.visitHelper(castedNode.cond, castedNode, currEnv);
+        castedNode.message && this.visitHelper(
           castedNode.message, castedNode, currEnv);
-        this.Visit(castedNode.rest, castedNode, currEnv);
+        this.visitHelper(castedNode.rest, castedNode, currEnv);
         return;
       }
       case "BinaryNode": {
         const castedNode = <ast.Binary>node;
-        this.VisitBinary(castedNode);
-        this.Visit(castedNode.left, castedNode, currEnv);
-        this.Visit(castedNode.right, castedNode, currEnv);
+        this.visitBinary(castedNode);
+        this.visitHelper(castedNode.left, castedNode, currEnv);
+        this.visitHelper(castedNode.right, castedNode, currEnv);
         return;
       }
       case "BuiltinNode": {
         const castedNode = <ast.Builtin>node;
-        this.VisitBuiltin(castedNode);
+        this.visitBuiltin(castedNode);
         return;
       }
       case "ConditionalNode": {
         const castedNode = <ast.Conditional>node;
-        this.VisitConditional(castedNode);
-        this.Visit(castedNode.cond, castedNode, currEnv);
-        this.Visit(castedNode.branchTrue, castedNode, currEnv);
-        castedNode.branchFalse && this.Visit(
+        this.visitConditional(castedNode);
+        this.visitHelper(castedNode.cond, castedNode, currEnv);
+        this.visitHelper(castedNode.branchTrue, castedNode, currEnv);
+        castedNode.branchFalse && this.visitHelper(
           castedNode.branchFalse, castedNode, currEnv);
         return;
       }
       case "DollarNode": {
         const castedNode = <ast.Dollar>node;
-        this.VisitDollar(castedNode);
+        this.visitDollar(castedNode);
         return;
       }
       case "ErrorNode": {
         const castedNode = <ast.ErrorNode>node;
-        this.VisitError(castedNode);
-        this.Visit(castedNode.expr, castedNode, currEnv);
+        this.visitError(castedNode);
+        this.visitHelper(castedNode.expr, castedNode, currEnv);
         return;
       }
       case "FunctionNode": {
         const castedNode = <ast.Function>node;
-        this.VisitFunction(castedNode);
+        this.visitFunction(castedNode);
 
         castedNode.headingComment.forEach((comment: ast.Comment) => {
-          this.Visit(comment, castedNode, currEnv);
+          this.visitHelper(comment, castedNode, currEnv);
         });
 
         // Add params to environment before visiting body.
@@ -166,49 +140,49 @@ export abstract class VisitorBase implements Visitor {
           ast.envFromParams(castedNode.parameters));
 
         castedNode.parameters.forEach((param: ast.FunctionParam) => {
-          this.Visit(param, castedNode, envWithParams);
+          this.visitHelper(param, castedNode, envWithParams);
         });
 
         // Visit body.
-        this.Visit(castedNode.body, castedNode, envWithParams);
+        this.visitHelper(castedNode.body, castedNode, envWithParams);
         castedNode.trailingComment.forEach((comment: ast.Comment) => {
           // NOTE: Using `currEnv` instead of `envWithparams`.
-          this.Visit(comment, castedNode, currEnv);
+          this.visitHelper(comment, castedNode, currEnv);
         });
         return;
       }
       case "FunctionParamNode": {
         const castedNode = <ast.FunctionParam>node;
-        castedNode.defaultValue && this.Visit(
+        castedNode.defaultValue && this.visitHelper(
           castedNode.defaultValue, castedNode, currEnv);
         return;
       }
       case "IdentifierNode": {
-        this.VisitIdentifier(<ast.Identifier>node);
+        this.visitIdentifier(<ast.Identifier>node);
         return;
       }
       case "ImportNode": {
-        this.VisitImport(<ast.Import>node);
+        this.visitImport(<ast.Import>node);
         return;
       }
       case "ImportStrNode": {
-        this.VisitImportStr(<ast.ImportStr>node);
+        this.visitImportStr(<ast.ImportStr>node);
         return;
       }
       case "IndexNode": {
         const castedNode = <ast.Index>node;
-        this.VisitIndex(castedNode);
-        castedNode.id != null && this.Visit(castedNode.id, castedNode, currEnv);
-        castedNode.target != null && this.Visit(
+        this.visitIndex(castedNode);
+        castedNode.id != null && this.visitHelper(castedNode.id, castedNode, currEnv);
+        castedNode.target != null && this.visitHelper(
           castedNode.target, castedNode, currEnv);
-        castedNode.index != null && this.Visit(
+        castedNode.index != null && this.visitHelper(
           castedNode.index, castedNode, currEnv);
         return;
       }
       // // case "LocalBindNode": return this.VisitLocalBind(<ast.LocalBind>node);
       case "LocalNode": {
         const castedNode = <ast.Local>node;
-        this.VisitLocal(castedNode);
+        this.visitLocal(castedNode);
 
         const envWithBinds = currEnv.merge(ast.envFromLocalBinds(castedNode));
         castedNode.binds.forEach((bind: ast.LocalBind) => {
@@ -221,56 +195,56 @@ export abstract class VisitorBase implements Visitor {
           // `LocalBind` currently does not implement `Node`. We
           // should decide whether that should change.
           bind.params.forEach((param: ast.FunctionParam) => {
-            this.Visit(param, castedNode, envWithParams)
+            this.visitHelper(param, castedNode, envWithParams)
           });
 
-          this.Visit(bind.body, castedNode, envWithParams);
+          this.visitHelper(bind.body, castedNode, envWithParams);
         });
 
-        this.Visit(castedNode.body, castedNode, envWithBinds);
+        this.visitHelper(castedNode.body, castedNode, envWithBinds);
         return;
       }
       case "LiteralBooleanNode": {
         const castedNode = <ast.LiteralBoolean>node;
-        this.VisitLiteralBoolean(castedNode);
+        this.visitLiteralBoolean(castedNode);
         return;
       }
       case "LiteralNullNode": {
         const castedNode = <ast.LiteralNull>node;
-        this.VisitLiteralNull(castedNode);
+        this.visitLiteralNull(castedNode);
         return;
       }
-      case "LiteralNumberNode": { return this.VisitLiteralNumber(<ast.LiteralNumber>node); }
+      case "LiteralNumberNode": { return this.visitLiteralNumber(<ast.LiteralNumber>node); }
       case "LiteralStringNode": {
         const castedNode = <ast.LiteralString>node;
-        this.VisitLiteralString(castedNode);
+        this.visitLiteralString(castedNode);
         return;
       }
       case "ObjectFieldNode": {
         const castedNode = <ast.ObjectField>node;
-        this.VisitObjectField(castedNode);
+        this.visitObjectField(castedNode);
 
         // NOTE: If `methodSugar` is false, the params will be empty.
         let envWithParams = currEnv.merge(ast.envFromParams(castedNode.ids));
 
-        castedNode.id != null && this.Visit(
+        castedNode.id != null && this.visitHelper(
           castedNode.id, castedNode, envWithParams);
-        castedNode.expr1 != null && this.Visit(
+        castedNode.expr1 != null && this.visitHelper(
           castedNode.expr1, castedNode, envWithParams);
 
         castedNode.ids.forEach((param: ast.FunctionParam) => {
-          this.Visit(param, castedNode, envWithParams);
+          this.visitHelper(param, castedNode, envWithParams);
         });
 
-        castedNode.expr2 != null && this.Visit(
+        castedNode.expr2 != null && this.visitHelper(
           castedNode.expr2, castedNode, envWithParams);
-        castedNode.expr3 != null && this.Visit(
+        castedNode.expr3 != null && this.visitHelper(
           castedNode.expr3, castedNode, envWithParams);
         castedNode.headingComments.forEach(comment => {
           if (comment == undefined) {
             throw new Error(`INTERNAL ERROR: element was undefined during a forEach call`);
           }
-          this.Visit(comment, castedNode, currEnv);
+          this.visitHelper(comment, castedNode, currEnv);
         });
         return;
       }
@@ -280,7 +254,7 @@ export abstract class VisitorBase implements Visitor {
           this.rootObject = castedNode;
           castedNode.rootObject = castedNode;
         }
-        this.VisitObject(castedNode);
+        this.visitObject(castedNode);
 
         // `local` object fields are scoped with order-independence,
         // so something like this is legal:
@@ -302,70 +276,70 @@ export abstract class VisitorBase implements Visitor {
           // remove current field from environment. It is perfectly
           // legal to do something like `local foo = foo; foo` (though
           // it will cause a stack overflow).
-          this.Visit(field, castedNode, envWithLocals);
+          this.visitHelper(field, castedNode, envWithLocals);
         });
         return;
       }
       case "DesugaredObjectFieldNode": {
         const castedNode = <ast.DesugaredObjectField>node;
-        this.VisitDesugaredObjectField(castedNode);
-        this.Visit(castedNode.name, castedNode, currEnv);
-        this.Visit(castedNode.body, castedNode, currEnv);
+        this.visitDesugaredObjectField(castedNode);
+        this.visitHelper(castedNode.name, castedNode, currEnv);
+        this.visitHelper(castedNode.body, castedNode, currEnv);
         return;
       }
       case "DesugaredObjectNode": {
         const castedNode = <ast.DesugaredObject>node;
-        this.VisitDesugaredObject(castedNode);
+        this.visitDesugaredObject(castedNode);
         castedNode.asserts.forEach((a: ast.Assert) => {
-          this.Visit(a, castedNode, currEnv);
+          this.visitHelper(a, castedNode, currEnv);
         });
         castedNode.fields.forEach((field: ast.DesugaredObjectField) => {
-          this.Visit(field, castedNode, currEnv);
+          this.visitHelper(field, castedNode, currEnv);
         });
         return;
       }
       case "ObjectCompNode": {
         const castedNode = <ast.ObjectComp>node;
-        this.VisitObjectComp(castedNode);
+        this.visitObjectComp(castedNode);
         castedNode.specs.forEach((spec: ast.CompSpec) => {
-          this.Visit(spec, castedNode, currEnv);
+          this.visitHelper(spec, castedNode, currEnv);
         });
         castedNode.fields.forEach((field: ast.ObjectField) => {
-          this.Visit(field, castedNode, currEnv);
+          this.visitHelper(field, castedNode, currEnv);
         });
         return;
       }
       case "ObjectComprehensionSimpleNode": {
         const castedNode = <ast.ObjectComprehensionSimple>node;
-        this.VisitObjectComprehensionSimple(castedNode);
-        this.Visit(castedNode.id, castedNode, currEnv);
-        this.Visit(castedNode.field, castedNode, currEnv);
-        this.Visit(castedNode.value, castedNode, currEnv);
-        this.Visit(castedNode.array, castedNode, currEnv);
+        this.visitObjectComprehensionSimple(castedNode);
+        this.visitHelper(castedNode.id, castedNode, currEnv);
+        this.visitHelper(castedNode.field, castedNode, currEnv);
+        this.visitHelper(castedNode.value, castedNode, currEnv);
+        this.visitHelper(castedNode.array, castedNode, currEnv);
         return;
       }
       case "SelfNode": {
         const castedNode = <ast.Self>node;
-        this.VisitSelf(castedNode);
+        this.visitSelf(castedNode);
         return;
       }
       case "SuperIndexNode": {
         const castedNode = <ast.SuperIndex>node;
-        this.VisitSuperIndex(castedNode);
-        castedNode.index && this.Visit(castedNode.index, castedNode, currEnv);
-        castedNode.id && this.Visit(castedNode.id, castedNode, currEnv);
+        this.visitSuperIndex(castedNode);
+        castedNode.index && this.visitHelper(castedNode.index, castedNode, currEnv);
+        castedNode.id && this.visitHelper(castedNode.id, castedNode, currEnv);
         return;
       }
       case "UnaryNode": {
         const castedNode = <ast.Unary>node;
-        this.VisitUnary(castedNode);
-        this.Visit(castedNode.expr, castedNode, currEnv);
+        this.visitUnary(castedNode);
+        this.visitHelper(castedNode.expr, castedNode, currEnv);
         return;
       }
       case "VarNode": {
         const castedNode = <ast.Var>node;
-        this.VisitVar(castedNode);
-        castedNode.id != null && this.Visit(castedNode.id, castedNode, currEnv);
+        this.visitVar(castedNode);
+        castedNode.id != null && this.visitHelper(castedNode.id, castedNode, currEnv);
         return
       }
       default: throw new Error(
@@ -373,130 +347,80 @@ export abstract class VisitorBase implements Visitor {
     }
   }
 
-  public abstract VisitComment = (node: ast.Comment): void => {}
-  public abstract VisitCompSpec = (node: ast.CompSpec): void => {}
-  public abstract VisitApply = (node: ast.Apply): void => {}
-  public abstract VisitApplyBrace = (node: ast.ApplyBrace): void => {}
-  public abstract VisitApplyParamAssignmentNode = (node: ast.ApplyParamAssignment): void => {}
-  public abstract VisitArray = (node: ast.Array): void => {}
-  public abstract VisitArrayComp = (node: ast.ArrayComp): void => {}
-  public abstract VisitAssert = (node: ast.Assert): void => {}
-  public abstract VisitBinary = (node: ast.Binary): void => {}
-  public abstract VisitBuiltin = (node: ast.Builtin): void => {}
-  public abstract VisitConditional = (node: ast.Conditional): void => {}
-  public abstract VisitDollar = (node: ast.Dollar): void => {}
-  public abstract VisitError = (node: ast.ErrorNode): void => {}
-  public abstract VisitFunction = (node: ast.Function): void => {}
+  protected onPrevisit = (
+    node: ast.Node, parent: ast.Node | null, currEnv: ast.Environment
+  ): void => {}
 
-  public abstract VisitIdentifier = (node: ast.Identifier): void => {}
-  public abstract VisitImport = (node: ast.Import): void => {}
-  public abstract VisitImportStr = (node: ast.ImportStr): void => {}
-  public abstract VisitIndex = (node: ast.Index): void => {}
+  protected visitComment = (node: ast.Comment): void => {}
+  protected visitCompSpec = (node: ast.CompSpec): void => {}
+  protected visitApply = (node: ast.Apply): void => {}
+  protected visitApplyBrace = (node: ast.ApplyBrace): void => {}
+  protected visitApplyParamAssignmentNode = (node: ast.ApplyParamAssignment): void => {}
+  protected visitArray = (node: ast.Array): void => {}
+  protected visitArrayComp = (node: ast.ArrayComp): void => {}
+  protected visitAssert = (node: ast.Assert): void => {}
+  protected visitBinary = (node: ast.Binary): void => {}
+  protected visitBuiltin = (node: ast.Builtin): void => {}
+  protected visitConditional = (node: ast.Conditional): void => {}
+  protected visitDollar = (node: ast.Dollar): void => {}
+  protected visitError = (node: ast.ErrorNode): void => {}
+  protected visitFunction = (node: ast.Function): void => {}
+
+  protected visitIdentifier = (node: ast.Identifier): void => {}
+  protected visitImport = (node: ast.Import): void => {}
+  protected visitImportStr = (node: ast.ImportStr): void => {}
+  protected visitIndex = (node: ast.Index): void => {}
   // // public abstract VisitLocalBind(node: ast.LocalBind): void
-  public abstract VisitLocal = (node: ast.Local): void => {}
+  protected visitLocal = (node: ast.Local): void => {}
 
-  public abstract VisitLiteralBoolean = (node: ast.LiteralBoolean): void => {}
-  public abstract VisitLiteralNull = (node: ast.LiteralNull): void => {}
+  protected visitLiteralBoolean = (node: ast.LiteralBoolean): void => {}
+  protected visitLiteralNull = (node: ast.LiteralNull): void => {}
 
-  public abstract VisitLiteralNumber = (node: ast.LiteralNumber): void => {}
-  public abstract VisitLiteralString = (node: ast.LiteralString): void => {}
-  public abstract VisitObjectField = (node: ast.ObjectField): void => {}
-  public abstract VisitObject = (node: ast.ObjectNode): void => {}
-  public abstract VisitDesugaredObjectField = (node: ast.DesugaredObjectField): void => {}
-  public abstract VisitDesugaredObject = (node: ast.DesugaredObject): void => {}
-  public abstract VisitObjectComp = (node: ast.ObjectComp): void => {}
-  public abstract VisitObjectComprehensionSimple = (node: ast.ObjectComprehensionSimple): void => {}
-  public abstract VisitSelf = (node: ast.Self): void => {}
-  public abstract VisitSuperIndex = (node: ast.SuperIndex): void => {}
-  public abstract VisitUnary = (node: ast.Unary): void => {}
-  public abstract VisitVar = (node: ast.Var): void => {}
+  protected visitLiteralNumber = (node: ast.LiteralNumber): void => {}
+  protected visitLiteralString = (node: ast.LiteralString): void => {}
+  protected visitObjectField = (node: ast.ObjectField): void => {}
+  protected visitObject = (node: ast.ObjectNode): void => {}
+  protected visitDesugaredObjectField = (node: ast.DesugaredObjectField): void => {}
+  protected visitDesugaredObject = (node: ast.DesugaredObject): void => {}
+  protected visitObjectComp = (node: ast.ObjectComp): void => {}
+  protected visitObjectComprehensionSimple = (node: ast.ObjectComprehensionSimple): void => {}
+  protected visitSelf = (node: ast.Self): void => {}
+  protected visitSuperIndex = (node: ast.SuperIndex): void => {}
+  protected visitUnary = (node: ast.Unary): void => {}
+  protected visitVar = (node: ast.Var): void => {}
 }
 
-export class DeserializingVisitor extends VisitorBase {
-  public VisitComment = (node: ast.Comment): void => {}
-  public VisitCompSpec = (node: ast.CompSpec): void => {}
-  public VisitApply = (node: ast.Apply): void => {}
-  public VisitApplyBrace = (node: ast.ApplyBrace): void => {}
-  public VisitApplyParamAssignmentNode = (node: ast.ApplyParamAssignment): void => {}
-  public VisitArray = (node: ast.Array): void => {}
-  public VisitArrayComp = (node: ast.ArrayComp): void => {}
-  public VisitAssert = (node: ast.Assert): void => {}
-  public VisitBinary = (node: ast.Binary): void => {}
-  public VisitBuiltin = (node: ast.Builtin): void => {}
-  public VisitConditional = (node: ast.Conditional): void => {}
-  public VisitDollar = (node: ast.Dollar): void => {}
-  public VisitError = (node: ast.ErrorNode): void => {}
-  public VisitFunction = (node: ast.Function): void => {}
-
-  public VisitIdentifier = (node: ast.Identifier): void => {}
-  public VisitImport = (node: ast.Import): void => {}
-  public VisitImportStr = (node: ast.ImportStr): void => {}
-  public VisitIndex = (node: ast.Index): void => {}
-  // // public abstract VisitLocalBind(node: ast.LocalBind): void
-  public VisitLocal = (node: ast.Local): void => {}
-  public VisitLiteralBoolean = (node: ast.LiteralBoolean): void => {}
-  public VisitLiteralNull = (node: ast.LiteralNull): void => {}
-  public VisitLiteralNumber = (node: ast.LiteralNumber): void => {}
-  public VisitLiteralString = (node: ast.LiteralString): void => {}
-  public VisitObjectField = (node: ast.ObjectField): void => {}
-  public VisitObject = (node: ast.ObjectNode): void => {}
-  public VisitDesugaredObjectField = (node: ast.DesugaredObjectField): void => {}
-  public VisitDesugaredObject = (node: ast.DesugaredObject): void => {}
-  public VisitObjectComp = (node: ast.ObjectComp): void => {}
-  public VisitObjectComprehensionSimple = (node: ast.ObjectComprehensionSimple): void => {}
-  public VisitSelf = (node: ast.Self): void => {}
-  public VisitSuperIndex = (node: ast.SuperIndex): void => {}
-  public VisitUnary = (node: ast.Unary): void => {}
-  public VisitVar = (node: ast.Var): void => {}
-
+export class InitializingVisitor extends VisitorBase {
+  protected onPrevisit = (
+    node: ast.Node, parent: ast.Node | null, currEnv: ast.Environment
+  ): void => {
+    node.parent = parent;
+    node.env = currEnv;
+    node.rootObject = this.rootObject;
+  }
 }
 
 // Finds the tightest-binding node that wraps the location denoted by
 // `position`.
 export class CursorVisitor extends VisitorBase {
-  constructor(private position: error.Location) { super(); }
+  constructor(
+    private position: error.Location,
+    root: ast.Node,
+  ) {
+    super(root);
+  }
 
   get NodeAtPosition(): ast.Node { return this.tightestWrappingNode; }
 
   private tightestWrappingNode: ast.Node;
 
-  public VisitComment = (node: ast.Comment): void => { this.updateIfCursorInRange(node); }
-  public VisitCompSpec = (node: ast.CompSpec): void => { this.updateIfCursorInRange(node); }
-  public VisitApply = (node: ast.Apply): void => { this.updateIfCursorInRange(node); }
-  public VisitApplyBrace = (node: ast.ApplyBrace): void => { this.updateIfCursorInRange(node); }
-  public VisitApplyParamAssignmentNode = (node: ast.ApplyParamAssignment): void => { this.updateIfCursorInRange(node); }
-  public VisitArray = (node: ast.Array): void => { this.updateIfCursorInRange(node); }
-  public VisitArrayComp = (node: ast.ArrayComp): void => { this.updateIfCursorInRange(node); }
-  public VisitAssert = (node: ast.Assert): void => { this.updateIfCursorInRange(node); }
-  public VisitBinary = (node: ast.Binary): void => { this.updateIfCursorInRange(node); }
-  public VisitBuiltin = (node: ast.Builtin): void => { this.updateIfCursorInRange(node); }
-  public VisitConditional = (node: ast.Conditional): void => { this.updateIfCursorInRange(node); }
-  public VisitDollar = (node: ast.Dollar): void => { this.updateIfCursorInRange(node); }
-  public VisitError = (node: ast.ErrorNode): void => { this.updateIfCursorInRange(node); }
-  public VisitFunction = (node: ast.Function): void => { this.updateIfCursorInRange(node); }
+  protected onPrevisit = (
+    node: ast.Node, parent: ast.Node | null, currEnv: ast.Environment,
+  ): void => {
+    this.updateTightestNode(node);
+  }
 
-  public VisitIdentifier = (node: ast.Identifier): void => { this.updateIfCursorInRange(node); }
-  public VisitImport = (node: ast.Import): void => { this.updateIfCursorInRange(node); }
-  public VisitImportStr = (node: ast.ImportStr): void => { this.updateIfCursorInRange(node); }
-  public VisitIndex = (node: ast.Index): void => { this.updateIfCursorInRange(node); }
-  // // public abstract VisitLocalBind(node: ast.LocalBind): void
-  public VisitLocal = (node: ast.Local): void => { this.updateIfCursorInRange(node); }
-  public VisitLiteralBoolean = (node: ast.LiteralBoolean): void => { this.updateIfCursorInRange(node); }
-  public VisitLiteralNull = (node: ast.LiteralNull): void => { this.updateIfCursorInRange(node); }
-  public VisitLiteralNumber = (node: ast.LiteralNumber): void => { this.updateIfCursorInRange(node); }
-  public VisitLiteralString = (node: ast.LiteralString): void => { this.updateIfCursorInRange(node); }
-  public VisitObjectField = (node: ast.ObjectField): void => { this.updateIfCursorInRange(node); }
-  public VisitObject = (node: ast.ObjectNode): void => { this.updateIfCursorInRange(node); }
-  public VisitDesugaredObjectField = (node: ast.DesugaredObjectField): void => { this.updateIfCursorInRange(node); }
-  public VisitDesugaredObject = (node: ast.DesugaredObject): void => { this.updateIfCursorInRange(node); }
-  public VisitObjectComp = (node: ast.ObjectComp): void => { this.updateIfCursorInRange(node); }
-  public VisitObjectComprehensionSimple = (node: ast.ObjectComprehensionSimple): void => { this.updateIfCursorInRange(node); }
-  public VisitSelf = (node: ast.Self): void => { this.updateIfCursorInRange(node); }
-  public VisitSuperIndex = (node: ast.SuperIndex): void => { this.updateIfCursorInRange(node); }
-  public VisitUnary = (node: ast.Unary): void => { this.updateIfCursorInRange(node); }
-  public VisitVar = (node: ast.Var): void => { this.updateIfCursorInRange(node); }
-
-  private updateIfCursorInRange = (node: ast.Node): ast.Node => {
+  private updateTightestNode = (node: ast.Node): void => {
     const locationRange = node.loc;
     const range = {
       beginLine: locationRange.begin.line,
@@ -514,8 +438,6 @@ export class CursorVisitor extends VisitorBase {
     ) {
       this.tightestWrappingNode = node;
     }
-
-    return this.tightestWrappingNode;
   }
 }
 

--- a/server/lexer/static_error.ts
+++ b/server/lexer/static_error.ts
@@ -18,6 +18,76 @@ export class Location {
   public String = (): string => {
     return `${this.line}:${this.column}`;
   };
+
+  public beforeRangeOrEqual = (range: LocationRange): boolean => {
+    const begin = range.begin;
+    if (this.line < begin.line) {
+      return true;
+    } else if (this.line == begin.line && this.column <= begin.column) {
+      return true;
+    }
+    return false;
+  }
+
+  public strictlyBeforeRange = (range: LocationRange): boolean => {
+    const begin = range.begin;
+    if (this.line < begin.line) {
+      return true;
+    } else if (this.line == begin.line && this.column < begin.column) {
+      return true;
+    }
+    return false;
+  }
+
+  public afterRangeOrEqual = (range: LocationRange): boolean => {
+    const end = range.end;
+    if (this.line > end.line) {
+      return true;
+    } else if (this.line == end.line && this.column >= end.column) {
+      return true;
+    }
+    return false;
+  }
+
+  public strictlyAfterRange = (range: LocationRange): boolean => {
+    const end = range.end;
+    if (this.line > end.line) {
+      return true;
+    } else if (this.line == end.line && this.column > end.column) {
+      return true;
+    }
+    return false;
+  }
+
+  public inRange = (loc: LocationRange): boolean => {
+    const range = {
+      beginLine: loc.begin.line,
+      endLine: loc.end.line,
+      beginCol: loc.begin.column,
+      endCol: loc.end.column,
+    }
+
+    if (
+      range.beginLine == this.line && this.line == range.endLine &&
+      range.beginCol <= this.column && this.column <= range.endCol
+    ) {
+      return true;
+    } else if (
+      range.beginLine < this.line && this.line == range.endLine &&
+      this.column <= range.endCol
+    ) {
+      return true;
+    } else if (
+      range.beginLine == this.line && this.line < range.endLine &&
+      this.column >= range.beginCol
+    ) {
+      return true;
+    } else if (range.beginLine < this.line && this.line < range.endLine) {
+      return true;
+    } else {
+      return false;
+    }
+  }
 }
 
 const emptyLocation = () => new Location(0, 0);
@@ -55,6 +125,10 @@ export class LocationRange {
     }
 
     return `${filePrefix}(${this.begin.String()})-(${this.end.String()})`;
+  }
+
+  public rangeIsTighter = (thatRange: LocationRange): boolean => {
+    return this.begin.inRange(thatRange) && this.end.inRange(thatRange);
   }
 }
 

--- a/server/local.ts
+++ b/server/local.ts
@@ -102,8 +102,6 @@ export class VsCompilerService implements compiler.CompilerService {
       const fail = new compiler.ParseFailure(lex, parse);
       return new compiler.FailedParsedDocument(text, fail, version);
     }
-    new astVisitor.DeserializingVisitor()
-      .Visit(parse, null, ast.emptyEnvironment);
 
     const parsedDoc = new compiler.ParsedDocument(text, lex, parse, version);
     this.docCache = this.docCache.set(fileUri, parsedDoc);

--- a/server/parser/node.ts
+++ b/server/parser/node.ts
@@ -242,7 +242,7 @@ export class Identifier extends NodeBase  {
   }
 }
 
-export const isIdentifier = (node: Node): node is Identifier => {
+export const isIdentifier = (node): node is Identifier => {
   return node instanceof Identifier;
 }
 
@@ -284,7 +284,7 @@ export class CppComment extends NodeBase implements Comment {
   }
 }
 
-export const isCppComment = (node: Node): node is Identifier => {
+export const isCppComment = (node): node is Identifier => {
   return node instanceof CppComment;
 }
 
@@ -323,7 +323,7 @@ export class CompSpecIf extends NodeBase implements CompSpec {
   }
 }
 
-export const isCompSpecIf = (node: Node): node is CompSpec => {
+export const isCompSpecIf = (node): node is CompSpec => {
   return node instanceof CompSpecIf;
 }
 
@@ -342,7 +342,7 @@ export class CompSpecFor extends NodeBase implements CompSpec {
   }
 }
 
-export const isCompSpecFor = (node: Node): node is CompSpec => {
+export const isCompSpecFor = (node): node is CompSpec => {
   return node instanceof CompSpecFor;
 }
 
@@ -374,7 +374,7 @@ export class Apply extends NodeBase  {
   }
 }
 
-export const isApply = (node: Node): node is Apply => {
+export const isApply = (node): node is Apply => {
   return node instanceof Apply;
 }
 
@@ -393,9 +393,7 @@ export class ApplyParamAssignment extends NodeBase {
 }
 export type ApplyParamAssignments = im.List<ApplyParamAssignment>
 
-export const isApplyParamAssignment = (
-  node: Node
-): node is ApplyParamAssignment => {
+export const isApplyParamAssignment = (node): node is ApplyParamAssignment => {
   return node instanceof ApplyParamAssignment;
 };
 
@@ -416,7 +414,7 @@ export class ApplyBrace extends NodeBase {
   }
 }
 
-export const isApplyBrace = (node: Node): node is ApplyBrace => {
+export const isApplyBrace = (node): node is ApplyBrace => {
   return node instanceof ApplyBrace;
 }
 
@@ -442,7 +440,7 @@ export class Array extends NodeBase {
   }
 }
 
-export const isArray = (node: Node): node is Array => {
+export const isArray = (node): node is Array => {
   return node instanceof Array;
 }
 
@@ -468,7 +466,7 @@ export class ArrayComp extends NodeBase {
   }
 }
 
-export const isArrayComp = (node: Node): node is ArrayComp => {
+export const isArrayComp = (node): node is ArrayComp => {
   return node instanceof ArrayComp;
 }
 
@@ -493,7 +491,7 @@ export class Assert extends NodeBase {
   }
 }
 
-export const isAssert = (node: Node): node is Assert => {
+export const isAssert = (node): node is Assert => {
   return node instanceof Assert;
 }
 
@@ -620,7 +618,7 @@ export class Binary extends NodeBase implements FieldsResolvable {
   }
 }
 
-export const isBinary = (node: Node): node is Binary => {
+export const isBinary = (node): node is Binary => {
   return node instanceof Binary;
 }
 
@@ -645,7 +643,7 @@ export class Builtin extends NodeBase {
   }
 }
 
-export const isBuiltin = (node: Node): node is Builtin => {
+export const isBuiltin = (node): node is Builtin => {
   return node instanceof Builtin;
 }
 
@@ -674,7 +672,7 @@ export class Conditional extends NodeBase {
   }
 }
 
-export const isConditional = (node: Node): node is Conditional => {
+export const isConditional = (node): node is Conditional => {
   return node instanceof Conditional;
 }
 
@@ -699,7 +697,7 @@ export class Dollar extends NodeBase implements Resolvable {
   }
 };
 
-export const isDollar = (node: Node): node is Dollar => {
+export const isDollar = (node): node is Dollar => {
   return node instanceof Dollar;
 }
 
@@ -719,7 +717,7 @@ export class ErrorNode extends NodeBase {
   }
 }
 
-export const isError = (node: Node): node is ErrorNode => {
+export const isError = (node): node is ErrorNode => {
   return node instanceof ErrorNode;
 }
 
@@ -746,7 +744,7 @@ export class Function extends NodeBase {
   }
 }
 
-export const isFunction = (node: Node): node is Function => {
+export const isFunction = (node): node is Function => {
   return node instanceof Function;
 }
 
@@ -768,7 +766,7 @@ export class FunctionParam extends NodeBase {
 }
 export type FunctionParams = im.List<FunctionParam>
 
-export const isFunctionParam = (node: any): node is FunctionParam => {
+export const isFunctionParam = (node): node is FunctionParam => {
   return node instanceof FunctionParam;
 }
 
@@ -814,7 +812,7 @@ export class Import extends NodeBase implements Resolvable {
   }
 }
 
-export const isImport = (node: Node): node is Import => {
+export const isImport = (node): node is Import => {
   return node instanceof Import;
 }
 
@@ -834,7 +832,7 @@ export class ImportStr extends NodeBase {
   }
 }
 
-export const isImportStr = (node: Node): node is ImportStr => {
+export const isImportStr = (node): node is ImportStr => {
   return node instanceof ImportStr;
 }
 
@@ -926,7 +924,7 @@ export class IndexSubscript extends NodeBase implements Index {
   ): Node | null => resolveIndex(this, compiler, documents);
 }
 
-export const isIndexSubscript = (node: Node): node is Index => {
+export const isIndexSubscript = (node): node is Index => {
   return node instanceof IndexSubscript;
 }
 
@@ -949,7 +947,7 @@ export class IndexDot extends NodeBase implements Index {
   ): Node | null => resolveIndex(this, compiler, documents);
 }
 
-export const isIndexDot = (node: Node): node is Index => {
+export const isIndexDot = (node): node is Index => {
   return node instanceof IndexDot;
 }
 
@@ -1006,7 +1004,7 @@ export class Local extends NodeBase {
   }
 }
 
-export const isLocal = (node: Node): node is Local => {
+export const isLocal = (node): node is Local => {
   return node instanceof Local;
 }
 
@@ -1026,7 +1024,7 @@ export class LiteralBoolean extends NodeBase {
   }
 }
 
-export const isLiteralBoolean = (node: Node): node is LiteralBoolean => {
+export const isLiteralBoolean = (node): node is LiteralBoolean => {
   return node instanceof LiteralBoolean;
 }
 
@@ -1045,7 +1043,7 @@ export class LiteralNull extends NodeBase {
   }
 }
 
-export const isLiteralNull = (node: Node): node is LiteralNull => {
+export const isLiteralNull = (node): node is LiteralNull => {
   return node instanceof LiteralNull;
 }
 
@@ -1066,7 +1064,7 @@ export class LiteralNumber extends NodeBase {
   }
 }
 
-export const isLiteralNumber = (node: Node): node is LiteralNumber => {
+export const isLiteralNumber = (node): node is LiteralNumber => {
   return node instanceof LiteralNumber;
 }
 
@@ -1105,9 +1103,7 @@ export class LiteralStringSingle extends NodeBase implements LiteralString {
   }
 }
 
-export const isLiteralStringSingle = (
-  node: Node
-): node is LiteralStringSingle => {
+export const isLiteralStringSingle = (node): node is LiteralStringSingle => {
   return node instanceof LiteralStringSingle;
 }
 
@@ -1126,7 +1122,7 @@ export class LiteralStringDouble extends NodeBase implements LiteralString {
   }
 }
 
-export const isLiteralStringDouble = (node: Node): node is LiteralString => {
+export const isLiteralStringDouble = (node): node is LiteralString => {
   return node instanceof LiteralStringDouble;
 }
 
@@ -1145,7 +1141,7 @@ export class LiteralStringBlock extends NodeBase implements LiteralString {
   }
 }
 
-export const isLiteralStringBlock = (node: Node): node is LiteralStringBlock => {
+export const isLiteralStringBlock = (node): node is LiteralStringBlock => {
   return node instanceof LiteralStringBlock;
 }
 
@@ -1214,7 +1210,7 @@ export class ObjectField extends NodeBase {
   }
 }
 
-export const isObjectField = (node: Node): node is ObjectField => {
+export const isObjectField = (node): node is ObjectField => {
   return node instanceof ObjectField;
 }
 
@@ -1306,7 +1302,7 @@ export class ObjectNode extends NodeBase implements FieldsResolvable {
   }
 }
 
-export const isObjectNode = (node: Node): node is ObjectNode => {
+export const isObjectNode = (node): node is ObjectNode => {
   return node instanceof ObjectNode;
 }
 
@@ -1361,7 +1357,7 @@ export class ObjectComp extends NodeBase {
   }
 }
 
-export const isObjectComp = (node: Node): node is ObjectComp => {
+export const isObjectComp = (node): node is ObjectComp => {
   return node instanceof ObjectComp;
 }
 
@@ -1401,7 +1397,7 @@ export class Self extends NodeBase {
   }
 };
 
-export const isSelf = (node: Node): node is Self => {
+export const isSelf = (node): node is Self => {
   return node instanceof Self;
 }
 
@@ -1430,7 +1426,7 @@ export class SuperIndex extends NodeBase {
   }
 }
 
-export const isSuperIndex = (node: Node): node is SuperIndex => {
+export const isSuperIndex = (node): node is SuperIndex => {
   return node instanceof SuperIndex;
 }
 
@@ -1471,7 +1467,7 @@ export class Unary extends NodeBase {
   }
 }
 
-export const isUnary = (node: Node): node is Unary => {
+export const isUnary = (node): node is Unary => {
   return node instanceof Unary;
 }
 
@@ -1505,7 +1501,7 @@ export class Var extends NodeBase implements Resolvable {
   }
 }
 
-export const isVar = (node: Node): node is Var => {
+export const isVar = (node): node is Var => {
   return node instanceof Var;
 }
 

--- a/server/parser/parser.ts
+++ b/server/parser/parser.ts
@@ -2,6 +2,7 @@
 import * as im from 'immutable';
 
 import * as ast from '../parser/node';
+import * as astVisitor from '../ast/visitor';
 import * as error from '../lexer/static_error';
 import * as lexer from '../lexer/lexer';
 
@@ -1310,6 +1311,7 @@ export const Parse = (
   if (p.peek().kind !== "TokenEndOfFile") {
     return error.MakeStaticError(`Did not expect: ${p.peek()}`, p.peek().loc);
   }
+  new astVisitor.InitializingVisitor(expr).visit();
 
   return expr;
 }

--- a/server/parser/parser.ts
+++ b/server/parser/parser.ts
@@ -484,7 +484,7 @@ class parser {
   // object, as an object field. `assertToken` is required to allow the
   // object to create an appropriate location range for the field.
   public parseObjectLocal = (
-    assertToken: lexer.Token, binds: ast.IdentifierSet,
+    localToken: lexer.Token, binds: ast.IdentifierSet,
   ): {field: ast.ObjectField, binds: ast.IdentifierSet} | error.StaticError => {
     const varID = this.popExpect("TokenIdentifier");
     if (error.isStaticError(varID)) {
@@ -533,13 +533,13 @@ class parser {
         body,
         null,
         im.List<ast.Comment>(),
-        locFromTokenAST(assertToken, body),
+        locFromTokenAST(localToken, body),
       ),
       binds: binds,
     };
   };
 
-  // parseObjectLocal parses an `assert` that appears as an object
+  // parseObjectAssert parses an `assert` that appears as an object
   // field. `localToken` is required to allow the object to create an
   // appropriate location range for the field.
   public parseObjectAssert = (

--- a/site/main.ts
+++ b/site/main.ts
@@ -111,8 +111,6 @@ export class BrowserCompilerService implements compiler.CompilerService {
       const fail = new compiler.ParseFailure(lex, parse);
       return new compiler.FailedParsedDocument(text, fail, version);
     }
-    new astVisitor.DeserializingVisitor()
-      .Visit(parse, null, ast.emptyEnvironment);
 
     const parsedDoc = new compiler.ParsedDocument(text, lex, parse, version);
     this.docCache = this.docCache.set(fileUri, parsedDoc);

--- a/test/server/analysis_tests.ts
+++ b/test/server/analysis_tests.ts
@@ -388,8 +388,8 @@ describe("Imported symbol resolution", () => {
         rootNode, makeLocation(4, 8));
     assert.isNotNull(importedSymbol);
     assert.equal(importedSymbol.type, "ObjectNode");
-    assert.isNull(importedSymbol.parent);
-    assertLocationRange(importedSymbol.loc, 1, 1, 12, 2);
+    assert.isNotNull(importedSymbol.parent);
+    assertLocationRange(importedSymbol.loc, 2, 1, 12, 2);
   });
 
   it("Can dereference fields from an imported module", () => {

--- a/test/server/parser/resolve_tests.ts
+++ b/test/server/parser/resolve_tests.ts
@@ -1,0 +1,326 @@
+'use strict';
+import { expect, assert } from 'chai';
+
+import * as ast from '../../../server/parser/node';
+import * as astVisitor from '../../../server/ast/visitor';
+import * as analyze from '../../../server/ast/analyzer';
+import * as local from '../../../server/local';
+import * as error from '../../../server/lexer/static_error';
+import * as lexer from '../../../server/lexer/lexer';
+import * as parser from '../../../server/parser/parser';
+import * as testWorkspace from '../test_workspace';
+
+class LocatedSpec {
+  constructor(
+    public locatedCheck: ast.NodeKind | null = null,
+  ) {}
+}
+
+class AnalyzableFailedLocatedSpec extends LocatedSpec {
+  constructor(
+    public locatedCheck: ast.NodeKind | null = null,
+  ) {
+    super(locatedCheck);
+  }
+}
+
+class UnanalyzableFailedLocatedSpec extends LocatedSpec {
+  constructor() {
+    super();
+  }
+}
+
+const isFailedLocatedSpec = (
+  spec
+): spec is AnalyzableFailedLocatedSpec | UnanalyzableFailedLocatedSpec => {
+  return spec instanceof AnalyzableFailedLocatedSpec ||
+    spec instanceof UnanalyzableFailedLocatedSpec;
+}
+
+const isAnalyzableFailedLocatedSpec = (
+  spec
+): spec is AnalyzableFailedLocatedSpec => {
+  return spec instanceof AnalyzableFailedLocatedSpec;
+}
+
+const isUnAnalyzableFailedLocatedSpec = (
+  spec
+): spec is UnanalyzableFailedLocatedSpec => {
+  return spec instanceof UnanalyzableFailedLocatedSpec;
+}
+
+class ResolvedSpec<TResolved extends ast.Node | ast.IndexedObjectFields> extends LocatedSpec {
+  constructor(
+    public locatedCheck: ast.NodeKind | null = null,
+    public resolvedTypeCheck: ast.NodeKind | null = null,
+    public assertions: (node: TResolved) => void = (node) => {}
+  ) {
+    super(locatedCheck);
+  }
+}
+
+const isResolvedSpec = <T1>(spec): spec is ResolvedSpec<T1> => {
+  return spec instanceof ResolvedSpec;
+}
+
+class FailedResolvedSpec<TResolveFailure extends ast.ResolveFailure> extends LocatedSpec {
+  constructor(
+    public assertions: (node: TResolveFailure) => void = (node) => {}
+  ) {
+    super();
+  }
+}
+
+const isFailedResolvedSpec = <T1>(spec): spec is FailedResolvedSpec<T1> => {
+  return spec instanceof FailedResolvedSpec;
+}
+
+class RangeSpec<TLocated extends ast.Node, TResolved extends ast.Node> {
+  constructor(
+    public name: string,
+    public line: number,
+    public beginCol: number,
+    public endCol: number,
+    public spec: LocatedSpec | ResolvedSpec<TResolved>,
+  ) {
+    if (beginCol > endCol) {
+      throw new Error(`Invalid range spec: begin column '${beginCol}' can't be less than end column '${endCol}'`);
+    }
+  }
+
+  public verifyRangeSpec = (root: ast.Node): void => {
+    for (let col = this.beginCol; col < this.endCol; col++) {
+      const coords = `(line: ${this.line}, col: ${col})`;
+
+      const spec = this.spec;
+      let found = analyzer.getNodeAtPositionFromAst(
+        root, new error.Location(this.line, col));
+
+      if (isAnalyzableFailedLocatedSpec(spec)) {
+        if (astVisitor.isAnalyzableFindFailure(found)) {
+          found = found.kind === "AfterLineEnd"
+            ? <ast.Node>found.terminalNodeOnCursorLine
+            : found.tightestEnclosingNode;
+        } else {
+          throw new Error(`Expected analyzable failure to locate node ${coords}`);
+        }
+      } else if (isUnAnalyzableFailedLocatedSpec(spec)) {
+        if (!astVisitor.isUnanalyzableFindFailure(found)) {
+          throw new Error(`Expected to unanalyzable failure to locate node ${coords}`);
+        }
+      }
+
+      if (spec.locatedCheck != null) {
+        if (astVisitor.isFindFailure(found)) {
+          throw new Error(`Expected to find a node ${coords}`);
+        }
+        assert.equal(found.type, spec.locatedCheck);
+      }
+
+      if (isResolvedSpec(spec)) {
+        if (astVisitor.isFindFailure(found)) {
+          throw new Error(`Expected to resolve node, but could not locate ${coords}`);
+        }
+        if (!ast.isResolvable(found)) {
+          throw new Error(`Expected to resolve node, but was not resolvable ${coords}`);
+        }
+        const resolved = found.resolve(compiler, documents);
+        if (ast.isResolveFailure(resolved)) {
+          throw new Error(`Expected to resolve node, but failed ${coords}`);
+        }
+
+        if (spec.resolvedTypeCheck != null) {
+          if (ast.isIndexedObjectFields(resolved)) {
+            throw new Error(`Expected to resolve to node, but resolved object fields failed ${coords}`);
+          }
+          assert.equal(resolved.type, spec.resolvedTypeCheck);
+        }
+        spec.assertions(resolved)
+      } else if (isFailedResolvedSpec(spec)) {
+        if (astVisitor.isFindFailure(found)) {
+          throw new Error(`Expected to resolve node, but could not locate ${coords}`);
+        }
+        if (!ast.isResolvable(found)) {
+          throw new Error(`Expected to find resolvable node, whose resolution fails, but node was not resolvable ${coords}`);
+        }
+
+        const resolved = found.resolve(compiler, documents);
+        if (!ast.isResolveFailure(resolved)) {
+          throw new Error(`Expected to fail to resolve node, but resolve succeeded ${coords}`);
+        }
+        spec.assertions(resolved);
+      }
+    }
+  }
+}
+
+const source = `
+{
+  local localVal1 = 3,
+  field1: localVal1,
+  local localVal2(param1) = param1,
+  field2:: localVal2,
+  local mixin1 = {foo: "bar"} + {bar: "baz"},
+  field3: mixin1,
+  local mixin2 = mixin1 + {foo: "foobar"},
+  field4: mixin2,
+  local object1 = {baz: "bat"},
+  local mixin3 = mixin2 + object1,
+  field5: mixin3,
+  local mixin4 = mixin3 + {foo+: "baz"},
+  field6: mixin4,
+}`;
+
+const ranges = [
+  new RangeSpec(
+    "locate failed when cursor before any nodes",
+    1, 1, 2, new UnanalyzableFailedLocatedSpec()),
+  new RangeSpec(
+    "locate failed when cursor before any nodes, and after range of text line",
+    1, 1, 2, new UnanalyzableFailedLocatedSpec()),
+  new RangeSpec(
+    "located `local` node in object",
+    3, 3, 9, new AnalyzableFailedLocatedSpec("ObjectFieldNode")),
+  new RangeSpec(
+    "resolved `localVal1` to number 3",
+    4, 11, 21,
+    new ResolvedSpec(
+      "IdentifierNode",
+      "LiteralNumberNode",
+      (node: ast.LiteralNumber) => node.originalString === "3")),
+  new RangeSpec(
+    "failed to find `localVal1` for location after end of line",
+    4, 22, 23, new AnalyzableFailedLocatedSpec("IdentifierNode")),
+  new RangeSpec(
+    "failed to resolve value for field2; resolve to function `localVal2`",
+    6, 12, 21,
+    new FailedResolvedSpec(
+      (fn: ast.ResolvedFunction) => {
+        ast.isObjectField(fn.functionNode) &&
+        fn.functionNode.id != null &&
+        fn.functionNode.id.name == "localVal2"
+      })),
+  new RangeSpec(
+    "resolved `mixin1` to fields",
+    8, 11, 17,
+    new ResolvedSpec<ast.IndexedObjectFields>(
+      null, null,
+      (fields: ast.IndexedObjectFields) => {
+        const foo = fields.get("foo");
+        assert.isTrue(foo && foo.expr2 && ast.isLiteralString(foo.expr2) &&
+          foo.expr2.value === "bar");
+        const bar = fields.get("bar");
+        assert.isTrue(bar && bar.expr2 && ast.isLiteralString(bar.expr2) &&
+          bar.expr2.value === "baz");
+      })),
+  new RangeSpec(
+    "recursively resolve `mixin2` to fields",
+    10, 11, 17,
+    new ResolvedSpec<ast.IndexedObjectFields>(
+      null, null,
+      (fields: ast.IndexedObjectFields) => {
+        const foo = fields.get("foo");
+        assert.isTrue(foo && foo.expr2 && ast.isLiteralString(foo.expr2) &&
+          foo.expr2.value === "foobar");
+
+        const bar = fields.get("bar");
+        assert.isTrue(bar && bar.expr2 && ast.isLiteralString(bar.expr2) &&
+          bar.expr2.value === "baz");
+      })),
+  new RangeSpec(
+    "recursively resolve `mixin3` to fields",
+    13, 11, 17,
+    new ResolvedSpec<ast.IndexedObjectFields>(
+      null, null,
+      (fields: ast.IndexedObjectFields) => {
+        const foo = fields.get("foo");
+        assert.isTrue(foo && foo.expr2 && ast.isLiteralString(foo.expr2) &&
+          foo.expr2.value === "foobar");
+
+        const bar = fields.get("bar");
+        assert.isTrue(bar && bar.expr2 && ast.isLiteralString(bar.expr2) &&
+          bar.expr2.value === "baz");
+
+        const baz = fields.get("baz");
+        assert.isTrue(baz && baz.expr2 && ast.isLiteralString(baz.expr2) &&
+          baz.expr2.value === "bat");
+      })),
+
+  // NOTE: This test will fail until we add support for super sugar in
+  // our resolution code. See comment in `analyzer.ts`.
+  // new RangeSpec(
+  //   "resolve `mixin3` to fields, with super sugar",
+  //   15, 11, 17,
+  //   new ResolvedSpec<ast.IndexedObjectFields>(
+  //     null, null,
+  //     (fields: ast.IndexedObjectFields) => {
+  //       const foo = fields.get("foo");
+  //       assert.isTrue(foo && foo.expr2 && ast.isLiteralString(foo.expr2) &&
+  //         foo.expr2.value === "foobarbaz");
+  //     })),
+];
+
+//
+// Setup.
+//
+
+const documents = new testWorkspace.FsDocumentManager()
+const compiler = new local.VsCompilerService();
+const analyzer = new analyze.Analyzer(documents, compiler)
+
+const tokens = lexer.Lex("test string", source);
+if (error.isStaticError(tokens)) {
+  throw new Error(`Failed to lex test source`);
+}
+
+const root = parser.Parse(tokens);
+if (error.isStaticError(root)) {
+  throw new Error(`Failed to parse test source`);
+}
+
+//
+// Tests
+//
+
+describe("Finding nodes by position", () => {
+  ranges.forEach(range => {
+    it(range.name, () => {
+      range.verifyRangeSpec(root);
+    });
+  })
+});
+
+//
+// Utilities
+//
+
+const resolveAt = (
+  root: ast.Node, line: number, column: number
+): ast.Node | null => {
+  const loc = new error.Location(line, column);
+  let node = analyzer.getNodeAtPositionFromAst(root, loc);
+  if (astVisitor.isAnalyzableFindFailure(node)) {
+    node = node.tightestEnclosingNode;
+  } else if (astVisitor.isUnanalyzableFindFailure(node)) {
+    return null;
+  }
+
+  if (ast.isResolvable(node)) {
+    const resolved = node.resolve(compiler, documents);
+    if (ast.isIndexedObjectFields(resolved) || ast.isResolveFailure(resolved)) {
+      return null;
+    }
+    return resolved;
+  }
+  return null;
+}
+
+const assertResolvesTo = <T extends ast.Node>(
+  line: number, column: number, isType: (node: ast.Node) => node is T,
+  assertions: (node: T) => void
+) => {
+  const resolved = <ast.Node>resolveAt(root, line, column);
+  assert.isNotNull(resolved);
+  assert.isTrue(isType(resolved));
+  assertions(<T>resolved);
+}

--- a/test/server/test_workspace.ts
+++ b/test/server/test_workspace.ts
@@ -1,0 +1,16 @@
+import * as fs from 'fs';
+import * as url from 'url';
+
+import * as workspace from '../../server/ast/workspace';
+
+export class FsDocumentManager implements workspace.DocumentManager {
+  public get = (fileUri: string) => {
+      const parsed = url.parse(fileUri);
+      if (parsed && parsed.path) {
+        // TODO: Perhaps make this a promise?
+        return {text: fs.readFileSync(parsed.path).toString(), version: -1};
+      }
+
+      throw new Error(`INTERNAL ERROR: Failed to parse URI '${fileUri}'`);
+  }
+}


### PR DESCRIPTION
There comments and the commit messages are written to stand on their own, so for context please look at those things. But for posterity, I will note that refactoring the `onComplete` logic is outside the scope of this patch set. That will come next.