### PR TITLE
Implement `onComplete` with new fail/resolve primitives

### DIFF
--- a/server/ast/analyzer.ts
+++ b/server/ast/analyzer.ts
@@ -243,13 +243,12 @@ export class Analyzer implements EventedAnalyzer {
     // Step 3, combine the partial parse and the environment
     // of the "best guess" to attempt to create meaningful
     // suggestions for the user.
-    //
-    // NOTE: Local binds don't inherit from `node`, so this is
-    // a special case.
-    const env = ast.isLocal(foundNode)
-      ? <ast.Environment>foundNode.body.env
-      : <ast.Environment>foundNode.env;
-    new astVisitor.InitializingVisitor(rest, foundNode, env).visit();
+    if (foundNode.env == null) {
+      throw new Error("INTERNAL ERROR: Node environment can't be null");
+    }
+    new astVisitor
+      .InitializingVisitor(rest, foundNode, foundNode.env)
+      .visit();
 
     // Create suggestions.
     return this.completionsFromNode(rest, cursorLoc, lastCharIsDot);

--- a/server/ast/analyzer.ts
+++ b/server/ast/analyzer.ts
@@ -110,101 +110,209 @@ export class Analyzer implements EventedAnalyzer {
         //
 
         try {
-          const parse = this.compilerService.cache(
+          const compiled = this.compilerService.cache(
             fileUri, doc.text, doc.version);
           const lines = doc.text.split("\n");
-          const c = lines[cursorLoc.line-1][cursorLoc.column-2];
 
-          let completions: service.CompletionInfo[] = [];
-          if (compiler.isFailedParsedDocument(parse)) {
-            // HACK. We should really be propagating the environment
-            // down through the parser, not through the visitor
-            // afterwards. If we did that, we would be able to use the
-            // env of the `rest` node below.
-            const lastParse = this.compilerService.getLastSuccess(fileUri);
-            if (lastParse == null || compiler.isLexFailure(parse.parse) || parse.parse.parseError.rest == null) {
-              return [];
-            }
+          // Lets us know whether the user has typed something like
+          // `foo` or `foo.` (i.e., whether they are "dotting into"
+          // `foo`). In the case of the latter, we will want to emit
+          // suggestions from the members of `foo`.
+          const lastCharIsDot =
+            lines[cursorLoc.line-1][cursorLoc.column-2] === ".";
 
-            let nodeAtPos = this.getNodeAtPositionFromAst(
-              lastParse.parse, cursorLoc);
-            if (astVisitor.isAnalyzableFindFailure(nodeAtPos)) {
-              nodeAtPos = nodeAtPos.tightestEnclosingNode;
-            } else if (astVisitor.isUnanalyzableFindFailure(nodeAtPos)) {
-              // TODO(hausdorff): Revisit this when we revamp the
-              // `onComplete` abstractions.
-              return [];
-            }
+          let node: ast.Node | null = null;
+          if (compiler.isParsedDocument(compiled)) {
+            // Success case. The document parses, and we can offer
+            // suggestions from a well-formed document.
 
-            const rest = parse.parse.parseError.rest;
-
-            // Local binds don't inherit from `node`, so this is a
-            // special case.
-            const env = ast.isLocal(nodeAtPos)
-              ? <ast.Environment>nodeAtPos.body.env
-              : <ast.Environment>nodeAtPos.env;
-            new astVisitor.InitializingVisitor(rest, nodeAtPos, env).visit();
-
-            const resolved = ast.tryResolveIndirections(
-              rest, this.compilerService, this.documents);
-            if (ast.isIndexedObjectFields(resolved)) {
-              return this.completableFields(resolved);
-            } else if (ast.isResolveFailure(resolved) && ast.isVar(rest)) {
-              return this.completionsFromIdentifier(rest.id);
-            }
-            return [];
-          } else if (c === ".") {
+            return this.completionsFromParse(
+              compiled, cursorLoc, lastCharIsDot);
+          } else {
             const lastParse = this.compilerService.getLastSuccess(fileUri);
             if (lastParse == null) {
               return [];
             }
-            let nodeAtPos = this.getNodeAtPositionFromAst(
-              lastParse.parse, cursorLoc);
-            if (astVisitor.isAnalyzableFindFailure(nodeAtPos)) {
-              nodeAtPos = nodeAtPos.tightestEnclosingNode;
-            } else if (astVisitor.isUnanalyzableFindFailure(nodeAtPos)) {
-              // TODO(hausdorff): Revisit this when we revamp the
-              // `onComplete` abstractions.
-              return [];
-            }
 
-            const resolved = ast.tryResolveIndirections(
-              nodeAtPos, this.compilerService, this.documents);
-            if (ast.isIndexedObjectFields(resolved)) {
-              return this.completableFields(resolved)
-            }
-            return [];
-          } else {
-            let nodeAtPos = this.getNodeAtPositionFromAst(
-              parse.parse, cursorLoc);
-            if (astVisitor.isAnalyzableFindFailure(nodeAtPos)) {
-              nodeAtPos = nodeAtPos.tightestEnclosingNode;
-            } else if (astVisitor.isUnanalyzableFindFailure(nodeAtPos)) {
-              // TODO(hausdorff): Revisit this when we revamp the
-              // `onComplete` abstractions.
-              return [];
-            }
-
-            if (!ast.isIdentifier(nodeAtPos)) {
-              // Attempt to resolve the node.
-              const resolved = ast.tryResolveIndirections(
-                nodeAtPos, this.compilerService, this.documents);
-              if (ast.isIndexedObjectFields(resolved)) {
-                return this.completableFields(resolved);
-              }
-              // TODO(hausdorff): Revisit this when we revamp the
-              // `onComplete` abstractions.
-               return [];
-            }
-
-            // Fallback on completing the identifier.
-            return this.completionsFromIdentifier(nodeAtPos);
+            return this.completionsFromFailedParse(
+              compiled, lastParse, cursorLoc, lastCharIsDot);
           }
         } catch (err) {
           console.log(err);
           return [];
         }
       });
+  }
+
+  //
+  // Completion methods.
+  //
+
+  // completionsFromParse takes a `ParsedDocument` (i.e., a
+  // successfully-parsed document), a cursor location, and an
+  // indication of whether the user is "dotting in" to a property, and
+  // produces a list of autocomplete suggestions.
+  public completionsFromParse = (
+    compiled: compiler.ParsedDocument, cursorLoc: error.Location,
+    lastCharIsDot: boolean,
+  ): service.CompletionInfo[] => {
+    // IMPLEMENTATION NOTES: We have kept this method relatively free
+    // of calls to `this` so that we don't have to mock out more of
+    // the analyzer to test it.
+
+    let foundNode = this.getNodeAtPositionFromAst(
+      compiled.parse, cursorLoc);
+    if (astVisitor.isAnalyzableFindFailure(foundNode)) {
+      if (foundNode.kind === "NotIdentifier") {
+        return [];
+      }
+      if (foundNode.terminalNodeOnCursorLine != null) {
+        foundNode = foundNode.terminalNodeOnCursorLine;
+      } else {
+        foundNode = foundNode.tightestEnclosingNode;
+      }
+    } else if (astVisitor.isUnanalyzableFindFailure(foundNode)) {
+      return [];
+    }
+
+    return this.completionsFromNode(foundNode, cursorLoc, lastCharIsDot);
+  }
+
+  // completionsFromFailedParse takes a `FailedParsedDocument` (i.e.,
+  // a document that does not parse), a `ParsedDocument` (i.e., a
+  // last-known good parse for the document), a cursor location, and
+  // an indication of whether the user is "dotting in" to a property,
+  // and produces a list of autocomplete suggestions.
+  public completionsFromFailedParse = (
+    compiled: compiler.FailedParsedDocument, lastParse: compiler.ParsedDocument,
+    cursorLoc: error.Location, lastCharIsDot: boolean,
+  ): service.CompletionInfo[] => {
+    // IMPLEMENTATION NOTES: We have kept this method relatively free
+    // of calls to `this` so that we don't have to mock out more of
+    // the analyzer to test it.
+    //
+    // Failure case. The document does not parse, so we need
+    // to:
+    //
+    // 1. Obtain a partial parse from the parser.
+    // 2. Get our "best guess" for where in the AST the user's
+    //    cursor would be, if the document did parse.
+    // 3. Use the partial parse and the environment "best
+    //    guess" to create suggestions based on the context
+    //    of where the user is typing.
+
+    if (
+      compiler.isLexFailure(compiled.parse) ||
+      compiled.parse.parseError.rest == null
+    ) {
+      return [];
+    }
+
+    // Step 1, get the "rest" of the parse, i.e., the partial
+    // parse emitted by the parser.
+    const rest = compiled.parse.parseError.rest;
+    const restEnd = rest.loc.end;
+
+    if (rest == null) {
+      throw new Error(`INTERNAL ERROR: rest should never be null`);
+    } else if (
+      !cursorLoc.inRange(rest.loc) &&
+      !(restEnd.line === cursorLoc.line && cursorLoc.column === restEnd.column + 1)
+    ) {
+      // Return no suggestions if the parse is not broken at
+      // the cursor.
+      //
+      // NOTE: the `+ 1` correctly captures the case of the
+      // user typing `.`.
+      return [];
+    }
+
+    // Step 2, try to find the "best guess".
+    let foundNode = this.getNodeAtPositionFromAst(
+      lastParse.parse, cursorLoc);
+    if (astVisitor.isAnalyzableFindFailure(foundNode)) {
+      if (foundNode.terminalNodeOnCursorLine != null) {
+        foundNode = foundNode.terminalNodeOnCursorLine;
+      } else {
+        foundNode = foundNode.tightestEnclosingNode;
+      }
+    } else if (astVisitor.isUnanalyzableFindFailure(foundNode)) {
+      return [];
+    }
+
+    // Step 3, combine the partial parse and the environment
+    // of the "best guess" to attempt to create meaningful
+    // suggestions for the user.
+    //
+    // NOTE: Local binds don't inherit from `node`, so this is
+    // a special case.
+    const env = ast.isLocal(foundNode)
+      ? <ast.Environment>foundNode.body.env
+      : <ast.Environment>foundNode.env;
+    new astVisitor.InitializingVisitor(rest, foundNode, env).visit();
+
+    // Create suggestions.
+    return this.completionsFromNode(rest, cursorLoc, lastCharIsDot);
+  }
+
+  // completionsFromNode takes a `Node`, a cursor location, and an
+  // indication of whether the user is "dotting in" to a property, and
+  // produces a list of autocomplete suggestions.
+  private completionsFromNode = (
+    node: ast.Node, cursorLoc: error.Location, lastCharIsDot: boolean,
+  ): service.CompletionInfo[] => {
+    // Attempt to resolve the node.
+    const resolved = ast.tryResolveIndirections(
+      node, this.compilerService, this.documents);
+
+    if (ast.isUnresolved(resolved)) {
+      // If we could not even partially resolve a node (as we do,
+      // e.g., when an index target resolves, but the ID doesn't),
+      // then create suggestions from the environment.
+      return node.env != null
+        ? envToSuggestions(node.env)
+        : [];
+    } else if (ast.isUnresolvedIndexTarget(resolved)) {
+      // One of the targets in some index expression failed to
+      // resolve, so we have no suggestions. For example, in
+      // `foo.bar.baz.bat`, if any of `foo`, `bar`, or `baz` fail,
+      // then we have nothing to suggest as the user is typing `bat`.
+      return [];
+    } else if (ast.isUnresolvedIndexId(resolved)) {
+      // We have successfully resolved index target, but not the index
+      // ID, so generate suggestions from the resolved target. For
+      // example, if the user types `foo.b`, then we would generate
+      // suggestions from the members of `foo`.
+      return this.completionsFromFields(resolved.resolvedTarget);
+    } else if (
+      ast.isResolvedFunction(resolved) ||
+      ast.isResolvedFreeVar(resolved) ||
+      (!lastCharIsDot && ast.isIndexedObjectFields(resolved) || ast.isNode(resolved))
+    ) {
+      // Our most complex case. One of two things is true:
+      //
+      // 1. Resolved the ID to a function or a free param, in which
+      //    case we do not want to emit any suggestions, or
+      // 2. The user has NOT typed a dot, AND the resolve node is not
+      //    fields addressable, OR it's a node. In other words, the
+      //    user has typed something like `foo` (and specifically not
+      //    `foo.`, which is covered in another case), and `foo`
+      //    completely resolves, either to a value (e.g., a number
+      //    like 3) or a set of fields (i.e., `foo` is an object). In
+      //    both cases the user has type variable, and we don't want
+      //    to suggest anything; if they wanted to see the members of
+      //    `foo`, they should type `foo.`.
+      return [];
+    } else if (lastCharIsDot && ast.isIndexedObjectFields(resolved)) {
+      // User has typed a dot, and the resolved symbol is
+      // fields-resolvable, so we can return the fields of the
+      // expression. For example, if the user types `foo.`, then we
+      // can suggest the members of `foo`.
+      return this.completionsFromFields(resolved);
+    }
+
+    // Catch-all case. Suggest nothing.
+    return [];
   }
 
   //
@@ -234,56 +342,7 @@ export class Analyzer implements EventedAnalyzer {
     ];
   }
 
-  private completionsFromIdentifier = (
-    node: ast.Node
-  ): service.CompletionInfo[] => {
-    //
-    // We suggest completions only for `Identifier` nodes that are in
-    // specific places in the AST. In particular, we would suggest a
-    // completion if the identifier is a:
-    //
-    // 1. Variable references, i.e., identifiers that reference
-    //    specific variables, that are in scope.
-    // 2. Identifiers that are part of an index expression, e.g.,
-    //    `foo.bar`.
-    //
-    // Note that requiring `node` to be an `Identifier` does
-    // disqualify autocompletions in places like comments or strings.
-    //
-
-    // Only suggest completions if the node is an identifier.
-    if (!ast.isIdentifier(node)) {
-      return [];
-    }
-
-    // Document root. Give suggestions from the environment if we have
-    // them. In a well-formed Jsonnet AST, this should not return
-    // valid responses, but return from the environment in case the
-    // tree parent was garbled somehow.
-    const parent = node.parent;
-    if (parent == null) {
-      return node.env && envToSuggestions(node.env) || [];
-    }
-
-    let resolved: ast.Node | ast.IndexedObjectFields | ast.ResolveFailure =
-      ast.Unresolved.Instance;
-    if (ast.isIndex(parent)) {
-      resolved = ast.tryResolveIndirections(
-        parent.target, this.compilerService, this.documents);
-    } else {
-      resolved = ast.tryResolveIndirections(
-        parent, this.compilerService, this.documents);
-    }
-
-    if (ast.isIndexedObjectFields(resolved)) {
-      return this.completableFields(resolved);
-    }
-
-    const suggestions = node.env && envToSuggestions(node.env) || [];
-    return suggestions
-  }
-
-  private completableFields = (
+  private completionsFromFields = (
     fieldSet: ast.IndexedObjectFields
   ): service.CompletionInfo[] => {
     // Attempt to get all the possible fields we could suggest. If the

--- a/server/ast/analyzer.ts
+++ b/server/ast/analyzer.ts
@@ -484,7 +484,7 @@ export class Analyzer implements EventedAnalyzer {
       // TODO: Handle this error without an exception.
       const err = compiler.isLexFailure(cached.parse)
         ? cached.parse.lexError.Error()
-        : cached.parse.parseError.Error()
+        : cached.parse.parseError.Error();
       throw new Error(
         `INTERNAL ERROR: Could not cache analysis of file ${fileUri}:\b${err}`);
     }
@@ -517,14 +517,13 @@ export class Analyzer implements EventedAnalyzer {
 //
 
 const envToSuggestions = (env: ast.Environment): service.CompletionInfo[] => {
-    return env.map((value, key) => {
-      if (value == null) {
-        throw new Error(`INTERNAL ERROR: Value in environment is null`);
-      }
+    return env.map((value: ast.LocalBind | ast.FunctionParam, key: string) => {
+      // TODO: Fill in documentation later. This might involve trying
+      // to parse function comment to get comments about different
+      // parameters.
       return <service.CompletionInfo>{
         label: key,
         kind: "Variable",
-        // TODO: Fill in documentaiton later.
       };
     })
     .toArray();

--- a/server/ast/visitor.ts
+++ b/server/ast/visitor.ts
@@ -240,10 +240,7 @@ export abstract class VisitorBase implements Visitor {
           castedNode.expr2, castedNode, envWithParams);
         castedNode.expr3 != null && this.visitHelper(
           castedNode.expr3, castedNode, envWithParams);
-        castedNode.headingComments.forEach(comment => {
-          if (comment == undefined) {
-            throw new Error(`INTERNAL ERROR: element was undefined during a forEach call`);
-          }
+        castedNode.headingComments.forEach((comment: ast.Comment) => {
           this.visitHelper(comment, castedNode, currEnv);
         });
         return;
@@ -510,7 +507,8 @@ export class CursorVisitor extends VisitorBase {
       } else if (this.cursor.strictlyAfterRange(this.terminalNode.loc)) {
         return new UnanalyzableFindFailure("AfterDocEnd");
       }
-      throw new Error("INTERNAL ERROR: No wrapping identifier was found, but node didn't lie outside of document range");
+      throw new Error(
+        "INTERNAL ERROR: No wrapping identifier was found, but node didn't lie outside of document range");
     } else if (!ast.isIdentifier(this.enclosingNode)) {
       if (
         this.terminalNodeOnCursorLine != null &&

--- a/server/lexer/lexer.ts
+++ b/server/lexer/lexer.ts
@@ -349,7 +349,8 @@ export class lexer {
   // next.
   public backup = () => {
     if (this.prevPos === LexEOFPos) {
-      throw new Error("backup called with no valid previous rune");
+      throw new Error(
+        "INTERNAL ERROR: backup called with no valid previous rune");
     }
     if ((this.prevPos - this.lineStart) < 0) {
       this.lineNumber = this.prevLineNumber;
@@ -365,7 +366,8 @@ export class lexer {
 
   public prevLocation = (): error.Location => {
     if (this.prevPos == LexEOFPos) {
-      throw new Error("prevLocation called with no valid previous rune");
+      throw new Error(
+        "INTERNAL ERROR: prevLocation called with no valid previous rune");
     }
     return new error.Location(
       this.prevLineNumber, this.prevPos - this.prevLineStart + 1);
@@ -461,7 +463,7 @@ export class lexer {
             state = "numAfterOneToNine";
           } else {
             // The caller should ensure the first rune is a digit.
-            throw new Error("Couldn't lex number");
+            throw new Error("INTERNAL ERROR: Couldn't lex number");
           }
           break;
         }
@@ -554,7 +556,7 @@ export class lexer {
   public lexIdentifier = () => {
     let r = this.next();
     if (!isIdentifierFirst(r)) {
-      throw new Error("Unexpected character in lexIdentifier");
+      throw new Error("INTERNAL ERROR: Unexpected character in lexIdentifier");
     }
     for (; r.codePoint != LexEOF.codePoint; r = this.next()) {
       if (!isIdentifier(r)) {
@@ -686,7 +688,7 @@ export class lexer {
 
       while (true) {
         if (numWhiteSpace <= 0) {
-          throw new Error("Unexpected value for numWhiteSpace");
+          throw new Error("INTERNAL ERROR: Unexpected value for numWhiteSpace");
         }
         this.acceptN(numWhiteSpace);
         for (r = this.next(); r.data !== '\n'; r = this.next()) {
@@ -723,10 +725,7 @@ export class lexer {
           }
           this.acceptN(3) // Skip '|||'
           const tokenData = cb
-            .map(rune => {
-              if (rune === undefined) {
-                throw new Error(`INTERNAL ERROR: Tried to \`map\` over rune list, but found a rune that was undefined:\n  runes:${cb}`);
-              }
+            .map((rune: rune) => {
               return rune.data;
             })
             .join("");

--- a/server/parser/node.ts
+++ b/server/parser/node.ts
@@ -1680,6 +1680,13 @@ export const isResolvedFreeVar = (thing): thing is ResolvedFreeVar => {
   return thing instanceof ResolvedFreeVar;
 }
 
+export type UnresolvedIndex = UnresolvedIndexTarget | UnresolvedIndexId;
+
+export const isUnresolvedIndex = (thing): thing is UnresolvedIndex => {
+  return thing instanceof UnresolvedIndexTarget ||
+    thing instanceof UnresolvedIndexId;
+}
+
 // UnresolvedIndexTarget represents a failure to resolve an `Index`
 // node because the target has failed to resolve.
 //

--- a/server/parser/node.ts
+++ b/server/parser/node.ts
@@ -20,10 +20,7 @@ export const envFromLocalBinds = (
     const defaultLocal: {[key: string]: LocalBind} = {};
     const binds = local.binds
       .reduce(
-        (acc, bind) => {
-          if (acc == undefined || bind == undefined) {
-            throw new Error(`INTERNAL ERROR: Local binds can't be undefined during a \`reduce\``);
-          }
+        (acc: {[key: string]: LocalBind}, bind: LocalBind) => {
           acc[bind.variable.name] = bind;
           return acc;
         },

--- a/server/parser/parser.ts
+++ b/server/parser/parser.ts
@@ -1261,7 +1261,8 @@ class parser {
                 return rhs;
               }
               if (bop == null) {
-                throw new Error("INTERNAL ERROR: `parse` can't return a null node unless an `error` is populated");
+                throw new Error(
+                  "INTERNAL ERROR: `parse` can't return a null node unless an `error` is populated");
               }
               lhs = new ast.Binary(lhs, bop, rhs, locFromTokenAST(begin, rhs));
               break;

--- a/server/parser/parser.ts
+++ b/server/parser/parser.ts
@@ -223,7 +223,7 @@ class parser {
   }
 
   public parseBind = (
-    binds: ast.LocalBinds
+    localToken: lexer.Token, binds: ast.LocalBinds
   ): ast.LocalBinds | error.StaticError => {
     const varID = this.popExpect("TokenIdentifier");
     if (error.isStaticError(varID)) {
@@ -255,7 +255,9 @@ class parser {
       }
       const id = new ast.Identifier(varID.data, varID.loc);
       const {params: params, gotComma: gotComma} = result;
-      const bind = ast.makeLocalBind(id, body, true, params, gotComma);
+      const location = locFromTokenAST(localToken, body);
+      const bind = new ast.LocalBind(
+        id, body, true, params, gotComma, location);
       binds = binds.push(bind);
     } else {
       const pop = this.popExpectOp("=");
@@ -267,8 +269,9 @@ class parser {
         return body;
       }
       const id = new ast.Identifier(varID.data, varID.loc);
-      const bind = ast.makeLocalBind(
-        id, body, false, im.List<ast.FunctionParam>(), false);
+      const location = locFromTokenAST(localToken, body);
+      const bind = new ast.LocalBind(
+        id, body, false, im.List<ast.FunctionParam>(), false, location);
       binds = binds.push(bind);
     }
 
@@ -1100,7 +1103,7 @@ class parser {
         this.pop();
         let binds = im.List<ast.LocalBind>();
         while (true) {
-          const newBinds = this.parseBind(binds);
+          const newBinds = this.parseBind(begin, binds);
           if (error.isStaticError(newBinds)) {
             return newBinds;
           }

--- a/test/server/analysis_tests.ts
+++ b/test/server/analysis_tests.ts
@@ -35,7 +35,7 @@ const resolveSymbolAtPositionFromAst = (
   analyzer: analyze.Analyzer, compilerService: compiler.CompilerService,
   documents: workspace.DocumentManager, rootNode: ast.Node, pos: error.Location,
 ): ast.Node | null => {
-  let nodeAtPos = analyzer.getNodeAtPositionFromAst(rootNode, pos);
+  let nodeAtPos = analyze.getNodeAtPositionFromAst(rootNode, pos);
   if (astVisitor.isAnalyzableFindFailure(nodeAtPos)) {
     nodeAtPos = nodeAtPos.tightestEnclosingNode;
   } else if (astVisitor.isUnanalyzableFindFailure(nodeAtPos)) {
@@ -177,7 +177,7 @@ describe("Searching an AST by position", () => {
   it("Object field assigned value of `local` symbol", () => {
     // Property.
     {
-      const property1Id = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+      const property1Id = <ast.Identifier>analyze.getNodeAtPositionFromAst(
         rootNode, makeLocation(2, 5));
       assert.isNotNull(property1Id);
       assert.equal(property1Id.type, "IdentifierNode");
@@ -193,7 +193,7 @@ describe("Searching an AST by position", () => {
 
     // Target.
     {
-      const target1Id = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+      const target1Id = <ast.Identifier>analyze.getNodeAtPositionFromAst(
         rootNode, makeLocation(2, 14));
       assert.isNotNull(target1Id);
       assert.equal(target1Id.type, "IdentifierNode");
@@ -216,7 +216,7 @@ describe("Searching an AST by position", () => {
   it("Object field assigned literal number", () => {
     // Target.
     const found =
-      <astVisitor.AnalyzableFindFailure>analyzer.getNodeAtPositionFromAst(
+      <astVisitor.AnalyzableFindFailure>analyze.getNodeAtPositionFromAst(
         rootNode, makeLocation(3, 15));
     assert.isTrue(astVisitor.isAnalyzableFindFailure(found));
     assert.equal(found.kind, "NotIdentifier");
@@ -236,7 +236,7 @@ describe("Searching an AST by position", () => {
   it("`local` object field assigned value", () => {
     // Property.
     {
-      const property3Id = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+      const property3Id = <ast.Identifier>analyze.getNodeAtPositionFromAst(
         rootNode, makeLocation(4, 9));
       assert.isNotNull(property3Id);
       assert.equal(property3Id.type, "IdentifierNode");
@@ -253,7 +253,7 @@ describe("Searching an AST by position", () => {
     // Target.
     {
       const found =
-        <astVisitor.AnalyzableFindFailure>analyzer.getNodeAtPositionFromAst(
+        <astVisitor.AnalyzableFindFailure>analyze.getNodeAtPositionFromAst(
           rootNode, makeLocation(4, 15));
       assert.isTrue(astVisitor.isAnalyzableFindFailure(found));
       assert.equal(found.kind, "NotIdentifier");
@@ -278,7 +278,7 @@ describe("Searching an AST by position", () => {
     // the current field. This tests that we correctly resolve that
     // reference, even though it occurs after the current object
     // field.
-    const property4Id = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+    const property4Id = <ast.Identifier>analyze.getNodeAtPositionFromAst(
       rootNode, makeLocation(5, 20));
     assert.isNotNull(property4Id);
     assert.equal(property4Id.type, "IdentifierNode");
@@ -294,7 +294,7 @@ describe("Searching an AST by position", () => {
   it("Can resolve identifiers that refer to mixins", () => {
     // merged1.b
     {
-      const merged1 = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+      const merged1 = <ast.Identifier>analyze.getNodeAtPositionFromAst(
         rootNode, makeLocation(11, 23));
       assert.isNotNull(merged1);
       assert.equal(merged1.type, "IdentifierNode");
@@ -309,7 +309,7 @@ describe("Searching an AST by position", () => {
 
     // merged2.a
     {
-      const merged2 = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+      const merged2 = <ast.Identifier>analyze.getNodeAtPositionFromAst(
         rootNode, makeLocation(11, 34));
       assert.isNotNull(merged2);
       assert.equal(merged2.type, "IdentifierNode");
@@ -324,7 +324,7 @@ describe("Searching an AST by position", () => {
 
     // merged3.a
     {
-      const merged3 = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+      const merged3 = <ast.Identifier>analyze.getNodeAtPositionFromAst(
         rootNode, makeLocation(11, 45));
       assert.isNotNull(merged3);
       assert.equal(merged3.type, "IdentifierNode");
@@ -339,7 +339,7 @@ describe("Searching an AST by position", () => {
 
     // merged4.a
     {
-      const merged4 = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+      const merged4 = <ast.Identifier>analyze.getNodeAtPositionFromAst(
         rootNode, makeLocation(11, 56));
       assert.isNotNull(merged4);
       assert.equal(merged4.type, "IdentifierNode");
@@ -354,7 +354,7 @@ describe("Searching an AST by position", () => {
 
     // merged4.a
     {
-      const merged5 = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+      const merged5 = <ast.Identifier>analyze.getNodeAtPositionFromAst(
         rootNode, makeLocation(15, 28));
       assert.isNotNull(merged5);
       assert.equal(merged5.type, "IdentifierNode");
@@ -373,7 +373,7 @@ describe("Searching an AST by position", () => {
     // points to another variable. In this case, `numberVal2` refers
     // to `numberVal1`.
 
-    const node = <ast.Identifier>analyzer.getNodeAtPositionFromAst(
+    const node = <ast.Identifier>analyze.getNodeAtPositionFromAst(
       rootNode, makeLocation(18, 19));
     assert.isNotNull(node);
     assert.equal(node.type, "IdentifierNode");

--- a/test/server/parser/completion_tests.ts
+++ b/test/server/parser/completion_tests.ts
@@ -1,0 +1,191 @@
+'use strict';
+import { expect, assert } from 'chai';
+
+import * as im from 'immutable';
+
+import * as ast from '../../../server/parser/node';
+import * as astVisitor from '../../../server/ast/visitor';
+import * as analyze from '../../../server/ast/analyzer';
+import * as compilerService from '../../../server/ast/compiler';
+import * as local from '../../../server/local';
+import * as error from '../../../server/lexer/static_error';
+import * as lexer from '../../../server/lexer/lexer';
+import * as parser from '../../../server/parser/parser';
+import * as service from '../../../server/ast/service';
+import * as testWorkspace from '../test_workspace';
+
+class SuccessfulParseCompletionTest {
+  private readonly completionSet: im.Set<string>;
+  constructor(
+    public readonly name: string,
+    public readonly source: string,
+    public readonly loc: error.Location,
+    readonly completions: string[],
+  ) {
+    this.completionSet = im.Set<string>(completions);
+  }
+
+  public runTest = async () => {
+    const documents = new testWorkspace.FsDocumentManager()
+    const compiler = new local.VsCompilerService();
+    const analyzer = new analyze.Analyzer(documents, compiler)
+
+    const tokens = lexer.Lex("test name", this.source);
+    if (error.isStaticError(tokens)) {
+      throw new Error(`Failed to lex test source`);
+    }
+
+    const root = parser.Parse(tokens);
+    if (error.isStaticError(root)) {
+      throw new Error(`Failed to parse test source`);
+    }
+
+    const parse = new compilerService.ParsedDocument(
+      this.source, tokens, root, 0);
+
+    const cis = await analyzer.completionsFromParse(parse, this.loc, false);
+    const completionSet = cis.reduce(
+      (acc, ci): im.Set<string> => {
+        return acc.add(ci.label);
+      },
+      im.Set<string>());
+
+    assert.isTrue(completionSet.equals(this.completionSet));
+  }
+}
+
+//
+// Autocomplete tests for successful parses.
+//
+
+const parsedCompletionTests = [
+  new SuccessfulParseCompletionTest(
+    "Simple object completion",
+    `local foo = "3"; {bar: f}`,
+    new error.Location(1, 25),
+    ["foo"]),
+  new SuccessfulParseCompletionTest(
+    "Simple local completion",
+    `local foo = "3"; local bar = f; {}`,
+    new error.Location(1, 31),
+    ["foo", "bar"]),
+  new SuccessfulParseCompletionTest(
+    "Simple end-of-document completion",
+    `local foo = "3"; f`,
+    new error.Location(1, 19),
+    ["foo"]),
+  new SuccessfulParseCompletionTest(
+    "Suggest nothing when identifier resolves",
+    `local foo = "3"; local bar = 4; foo`,
+    new error.Location(1, 36),
+    []),
+  new SuccessfulParseCompletionTest(
+    "Suggest both variables in environment",
+    `local foo = "3"; local bar = 4; f`,
+    new error.Location(1, 36),
+    ["foo", "bar"]),
+  new SuccessfulParseCompletionTest(
+    "Don't suggest from inside the `local` keyword",
+    `local foo = "3"; {}`,
+    new error.Location(1, 3),
+    []),
+  new SuccessfulParseCompletionTest(
+    "Don't suggest from inside a string literal",
+    `local foo = "3"; {bar: "f"}`,
+    new error.Location(1, 26),
+    []),
+  new SuccessfulParseCompletionTest(
+    "Don't suggest from inside a number literal",
+    `local foo = "3"; {bar: 32}`,
+    new error.Location(1, 25),
+    []),
+  new SuccessfulParseCompletionTest(
+    "Don't suggest from inside a comment",
+    `{} // This is a comment`,
+    new error.Location(1, 14),
+    []),
+  new SuccessfulParseCompletionTest(
+    "Suggest nothing if index ID resolves to object field",
+    `local foo = {bar: "bar", baz: "baz"}; foo.bar`,
+    new error.Location(1, 46),
+    []),
+  new SuccessfulParseCompletionTest(
+    "Suggest only name of index ID if it resolves to object field",
+    `local foo = {bar: "bar", baz: "baz"}; foo.ba`,
+    new error.Location(1, 45),
+    ["bar", "baz"]),
+  new SuccessfulParseCompletionTest(
+    "Suggest name if ID resolves to object",
+    `local foo = {bar: "bar", baz: "baz"}; foo`,
+    new error.Location(1, 42),
+    []),
+  new SuccessfulParseCompletionTest(
+    "Don't suggest completions for members that aren't completable",
+    `local foo = {bar: "bar", baz: "baz"}; foo.bar.b`,
+    new error.Location(1, 48),
+    []),
+  new SuccessfulParseCompletionTest(
+    "Don't suggest completions when target is index with invalid id",
+    `local foo = {bar: "bar", baz: "baz"}; foo.bat.b`,
+    new error.Location(1, 48),
+    []),
+  new SuccessfulParseCompletionTest(
+    "Follow mixins for suggestions",
+    `local foo = {bar: "bar"} + {baz: "baz"}; foo.ba`,
+    new error.Location(1, 48),
+    ["bar", "baz"]),
+
+  // Tests that will work as `onComplete` becomes more feature-ful.
+  // new CompletionTest(
+  //   "Don't get hung up when references form an infinite loop",
+  //   `local foo = foo; foo`,
+  //   new error.Location(1, 25),
+  //   []),
+  // new CompletionTest(
+  //   "Simple suggestion through `self`",
+  //   `{bar: 42, foo: self.b}`,
+  //   new error.Location(1, 22),
+  //   ["bar", "foo"]),
+  // new CompletionTest(
+  //   "Simple suggestion through `self`",
+  //   `{bar: 42} + {foo: super.b}`,
+  //   new error.Location(1, 22),
+  //   ["bar", "foo"]),
+  // new SuccessfulParseCompletionTest(
+  //   "Failed to complete from field name",
+  //   `local foo = "3"; {f: 4}`,
+  //   new error.Location(1, 20),
+  //   []),
+
+  // May or may not make sense.
+  // new CompletionTest(
+  //   "Suggest only the name in an apply",
+  //   `local foo() = 3; local bar = 4; foo()`,
+  //   new error.Location(1, 21),
+  //   ["foo"]),
+  // new SuccessfulParseCompletionTest(
+  //   "Don't suggest completions from within index",
+  //   `local foo = {bar: "bar", baz: "baz"}; foo.bar.b`,
+  //   new error.Location(1, 45),
+  //   []),
+];
+
+//
+// Setup.
+//
+
+const documents = new testWorkspace.FsDocumentManager()
+const compiler = new local.VsCompilerService();
+const analyzer = new analyze.Analyzer(documents, compiler)
+
+//
+// Tests
+//
+
+describe("Suggestions for successful parses", () => {
+  parsedCompletionTests.forEach(range => {
+    it(range.name, async () => {
+      await range.runTest();
+    });
+  })
+});

--- a/test/server/parser/resolve_tests.ts
+++ b/test/server/parser/resolve_tests.ts
@@ -93,7 +93,7 @@ class RangeSpec<TLocated extends ast.Node, TResolved extends ast.Node> {
       const coords = `(line: ${this.line}, col: ${col})`;
 
       const spec = this.spec;
-      let found = analyzer.getNodeAtPositionFromAst(
+      let found = analyze.getNodeAtPositionFromAst(
         root, new error.Location(this.line, col));
 
       if (isAnalyzableFailedLocatedSpec(spec)) {
@@ -298,7 +298,7 @@ const resolveAt = (
   root: ast.Node, line: number, column: number
 ): ast.Node | null => {
   const loc = new error.Location(line, column);
-  let node = analyzer.getNodeAtPositionFromAst(root, loc);
+  let node = analyze.getNodeAtPositionFromAst(root, loc);
   if (astVisitor.isAnalyzableFindFailure(node)) {
     node = node.tightestEnclosingNode;
   } else if (astVisitor.isUnanalyzableFindFailure(node)) {


### PR DESCRIPTION
This PR will:
* Bring us to feature parity with the old autocompletion code.
* Fix all known bugs in the node-finding and symbol resolution code.
* Add significant tests for the resolution path.