### PR TITLE
add support for handling ksonnet components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 out
 node_modules
+.vscode-test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3967 @@
+{
+    "name": "jsonnet",
+    "version": "0.0.15",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@types/chai": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
+            "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4=",
+            "dev": true
+        },
+        "@types/mocha": {
+            "version": "2.2.48",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+            "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "6.0.101",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
+            "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw==",
+            "dev": true
+        },
+        "JSONStream": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
+            "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+            "dev": true,
+            "requires": {
+                "jsonparse": "1.3.1",
+                "through": "2.3.8"
+            }
+        },
+        "acorn": {
+            "version": "4.0.13",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+            "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+            "dev": true
+        },
+        "acorn-node": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.3.0.tgz",
+            "integrity": "sha512-efP54n3d1aLfjL2UMdaXa6DsswwzJeI5rqhbFvXMrKiJ6eJFpf+7R0zN7t8IC+XKn2YOAFAv6xbBNgHUkoHWLw==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.4.1",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+                    "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "ajv": {
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "dev": true,
+            "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.0.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+            }
+        },
+        "ansi-cyan": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+            "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-gray": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+            "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-red": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+            "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+            "dev": true,
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "ansi-wrap": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "requires": {
+                "sprintf-js": "1.0.3"
+            }
+        },
+        "arr-diff": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+            "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "1.1.0",
+                "array-slice": "0.2.3"
+            }
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
+        },
+        "arr-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+            "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
+            "dev": true
+        },
+        "array-differ": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+            "dev": true
+        },
+        "array-filter": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+            "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+            "dev": true
+        },
+        "array-map": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+            "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+            "dev": true
+        },
+        "array-reduce": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+            "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+            "dev": true
+        },
+        "array-slice": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+            "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+            "dev": true
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "1.0.3"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "asn1": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+            "dev": true
+        },
+        "asn1.js": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
+            "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
+        },
+        "assert": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+            "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+            "dev": true,
+            "requires": {
+                "util": "0.10.3"
+            }
+        },
+        "assert-plus": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+            "dev": true
+        },
+        "assertion-error": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "dev": true
+        },
+        "astw": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+            "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
+            "dev": true,
+            "requires": {
+                "acorn": "4.0.13"
+            }
+        },
+        "asynckit": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
+        },
+        "aws-sign2": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+            "dev": true
+        },
+        "aws4": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "base64-js": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
+            "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
+            "dev": true
+        },
+        "bcrypt-pbkdf": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "tweetnacl": "0.14.5"
+            }
+        },
+        "beeper": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+            "dev": true
+        },
+        "block-stream": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+            "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
+        "bluebird": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.0.5.tgz",
+            "integrity": "sha1-L/nQfJs+2ynW0oD+B1KDZefs05I="
+        },
+        "bn.js": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+            "dev": true
+        },
+        "boom": {
+            "version": "2.10.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+            "dev": true,
+            "requires": {
+                "hoek": "2.16.3"
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "dev": true,
+            "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+            }
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+            "dev": true
+        },
+        "browser-pack": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.4.tgz",
+            "integrity": "sha512-Q4Rvn7P6ObyWfc4stqLWHtG1MJ8vVtjgT24Zbu+8UTzxYuZouqZsmNRRTFVMY/Ux0eIKv1d+JWzsInTX+fdHPQ==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.2",
+                "combine-source-map": "0.8.0",
+                "defined": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "through2": "2.0.3",
+                "umd": "3.0.1"
+            }
+        },
+        "browser-resolve": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+            "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+            "dev": true,
+            "requires": {
+                "resolve": "1.1.7"
+            },
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
+            }
+        },
+        "browser-stdout": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+            "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+            "dev": true
+        },
+        "browserify": {
+            "version": "14.5.0",
+            "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.5.0.tgz",
+            "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.2",
+                "assert": "1.4.1",
+                "browser-pack": "6.0.4",
+                "browser-resolve": "1.11.2",
+                "browserify-zlib": "0.2.0",
+                "buffer": "5.1.0",
+                "cached-path-relative": "1.0.1",
+                "concat-stream": "1.5.2",
+                "console-browserify": "1.1.0",
+                "constants-browserify": "1.0.0",
+                "crypto-browserify": "3.12.0",
+                "defined": "1.0.0",
+                "deps-sort": "2.0.0",
+                "domain-browser": "1.1.7",
+                "duplexer2": "0.1.4",
+                "events": "1.1.1",
+                "glob": "7.1.2",
+                "has": "1.0.1",
+                "htmlescape": "1.1.1",
+                "https-browserify": "1.0.0",
+                "inherits": "2.0.3",
+                "insert-module-globals": "7.0.1",
+                "labeled-stream-splicer": "2.0.0",
+                "module-deps": "4.1.1",
+                "os-browserify": "0.3.0",
+                "parents": "1.0.1",
+                "path-browserify": "0.0.0",
+                "process": "0.11.10",
+                "punycode": "1.4.1",
+                "querystring-es3": "0.2.1",
+                "read-only-stream": "2.0.0",
+                "readable-stream": "2.3.4",
+                "resolve": "1.5.0",
+                "shasum": "1.0.2",
+                "shell-quote": "1.6.1",
+                "stream-browserify": "2.0.1",
+                "stream-http": "2.8.0",
+                "string_decoder": "1.0.3",
+                "subarg": "1.0.0",
+                "syntax-error": "1.4.0",
+                "through2": "2.0.3",
+                "timers-browserify": "1.4.2",
+                "tty-browserify": "0.0.1",
+                "url": "0.11.0",
+                "util": "0.10.3",
+                "vm-browserify": "0.0.4",
+                "xtend": "4.0.1"
+            }
+        },
+        "browserify-aes": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+            "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
+            "dev": true,
+            "requires": {
+                "buffer-xor": "1.0.3",
+                "cipher-base": "1.0.4",
+                "create-hash": "1.1.3",
+                "evp_bytestokey": "1.0.3",
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "browserify-cipher": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+            "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+            "dev": true,
+            "requires": {
+                "browserify-aes": "1.1.1",
+                "browserify-des": "1.0.0",
+                "evp_bytestokey": "1.0.3"
+            }
+        },
+        "browserify-des": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+            "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "des.js": "1.0.0",
+                "inherits": "2.0.3"
+            }
+        },
+        "browserify-rsa": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "randombytes": "2.0.6"
+            }
+        },
+        "browserify-sign": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+            "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "elliptic": "6.4.0",
+                "inherits": "2.0.3",
+                "parse-asn1": "5.1.0"
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "dev": true,
+            "requires": {
+                "pako": "1.0.6"
+            }
+        },
+        "buffer": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+            "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
+            "dev": true,
+            "requires": {
+                "base64-js": "1.2.3",
+                "ieee754": "1.1.8"
+            }
+        },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
+        },
+        "buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+            "dev": true
+        },
+        "builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+            "dev": true
+        },
+        "cached-path-relative": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+            "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
+            "dev": true
+        },
+        "caseless": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+            "dev": true
+        },
+        "chai": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+            "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+            "dev": true,
+            "requires": {
+                "assertion-error": "1.1.0",
+                "deep-eql": "0.1.3",
+                "type-detect": "1.0.0"
+            }
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.2",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+            },
+            "dependencies": {
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "cipher-base": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "clone": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+            "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8=",
+            "dev": true
+        },
+        "clone-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+            "dev": true
+        },
+        "clone-stats": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+            "dev": true
+        },
+        "cloneable-readable": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
+            "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "process-nextick-args": "1.0.7",
+                "through2": "2.0.3"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                    "dev": true
+                }
+            }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "color-support": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+            "dev": true
+        },
+        "combine-source-map": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+            "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "1.1.3",
+                "inline-source-map": "0.6.2",
+                "lodash.memoize": "3.0.4",
+                "source-map": "0.5.7"
+            }
+        },
+        "combined-stream": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+            "dev": true,
+            "requires": {
+                "delayed-stream": "1.0.0"
+            }
+        },
+        "commander": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "concat-stream": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+            "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.0.6",
+                "typedarray": "0.0.6"
+            },
+            "dependencies": {
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+                    "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "console-browserify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "dev": true,
+            "requires": {
+                "date-now": "0.1.4"
+            }
+        },
+        "constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+            "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "create-ecdh": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+            "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "elliptic": "6.4.0"
+            }
+        },
+        "create-hash": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+            "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.1",
+                "sha.js": "2.4.10"
+            }
+        },
+        "create-hmac": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+            "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+            "dev": true,
+            "requires": {
+                "cipher-base": "1.0.4",
+                "create-hash": "1.1.3",
+                "inherits": "2.0.3",
+                "ripemd160": "2.0.1",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.10"
+            }
+        },
+        "cryptiles": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+            "dev": true,
+            "requires": {
+                "boom": "2.10.1"
+            }
+        },
+        "crypto-browserify": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "dev": true,
+            "requires": {
+                "browserify-cipher": "1.0.0",
+                "browserify-sign": "4.0.4",
+                "create-ecdh": "4.0.0",
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "diffie-hellman": "5.0.2",
+                "inherits": "2.0.3",
+                "pbkdf2": "3.0.14",
+                "public-encrypt": "4.0.0",
+                "randombytes": "2.0.6",
+                "randomfill": "1.0.4"
+            }
+        },
+        "dashdash": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "date-now": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
+        },
+        "dateformat": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+            "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
+            "dev": true
+        },
+        "debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "deep-assign": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-1.0.0.tgz",
+            "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
+            "dev": true,
+            "requires": {
+                "is-obj": "1.0.1"
+            }
+        },
+        "deep-eql": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+            "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+            "dev": true,
+            "requires": {
+                "type-detect": "0.1.1"
+            },
+            "dependencies": {
+                "type-detect": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+                    "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+                    "dev": true
+                }
+            }
+        },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+            "dev": true
+        },
+        "delayed-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
+        },
+        "deps-sort": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+            "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.2",
+                "shasum": "1.0.2",
+                "subarg": "1.0.0",
+                "through2": "2.0.3"
+            }
+        },
+        "des.js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+            "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
+        },
+        "detective": {
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+            "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.4.1",
+                "defined": "1.0.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+                    "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "diff": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+            "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+            "dev": true
+        },
+        "diffie-hellman": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+            "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "miller-rabin": "4.0.1",
+                "randombytes": "2.0.6"
+            }
+        },
+        "domain-browser": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+            "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+            "dev": true
+        },
+        "duplexer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+            "dev": true
+        },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.4"
+            }
+        },
+        "duplexify": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
+            "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "1.4.1",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4",
+                "stream-shift": "1.0.0"
+            }
+        },
+        "ecc-jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "jsbn": "0.1.1"
+            }
+        },
+        "elliptic": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+            "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.3",
+                "hmac-drbg": "1.0.1",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
+            }
+        },
+        "end-of-stream": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+            "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+            "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+        },
+        "event-stream": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+            "dev": true,
+            "requires": {
+                "duplexer": "0.1.1",
+                "from": "0.1.7",
+                "map-stream": "0.1.0",
+                "pause-stream": "0.0.11",
+                "split": "0.3.3",
+                "stream-combiner": "0.0.4",
+                "through": "2.3.8"
+            }
+        },
+        "events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "dev": true
+        },
+        "evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "dev": true,
+            "requires": {
+                "md5.js": "1.3.4",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "dev": true,
+            "requires": {
+                "is-posix-bracket": "0.1.1"
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "dev": true,
+            "requires": {
+                "fill-range": "2.2.3"
+            }
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+            "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+            "dev": true,
+            "requires": {
+                "kind-of": "1.1.0"
+            }
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "1.0.0"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                }
+            }
+        },
+        "extsprintf": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
+        },
+        "fancy-log": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+            "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+            "dev": true,
+            "requires": {
+                "ansi-gray": "0.1.1",
+                "color-support": "1.1.3",
+                "time-stamp": "1.1.0"
+            }
+        },
+        "fast-deep-equal": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "fd-slicer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "dev": true,
+            "requires": {
+                "pend": "1.2.0"
+            }
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "dev": true
+        },
+        "filepath": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/filepath/-/filepath-1.1.0.tgz",
+            "integrity": "sha1-173JSJbZdS+o+iN+J16emOYwmO0=",
+            "requires": {
+                "bluebird": "3.0.5"
+            }
+        },
+        "fill-range": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "dev": true,
+            "requires": {
+                "is-number": "2.1.0",
+                "isobject": "2.1.0",
+                "randomatic": "1.1.7",
+                "repeat-element": "1.1.2",
+                "repeat-string": "1.6.1"
+            }
+        },
+        "first-chunk-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
+            "dev": true
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true,
+            "requires": {
+                "for-in": "1.0.2"
+            }
+        },
+        "forever-agent": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+            "dev": true,
+            "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "2.1.18"
+            }
+        },
+        "from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fstream": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+            "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.2"
+            }
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "generate-function": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+            "dev": true
+        },
+        "generate-object-property": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+            "dev": true,
+            "requires": {
+                "is-property": "1.0.2"
+            }
+        },
+        "getpass": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true,
+            "requires": {
+                "glob-parent": "2.0.0",
+                "is-glob": "2.0.1"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "2.0.1"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                }
+            }
+        },
+        "glob-parent": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+            "dev": true,
+            "requires": {
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
+            }
+        },
+        "glob-stream": {
+            "version": "5.3.5",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
+            "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+            "dev": true,
+            "requires": {
+                "extend": "3.0.1",
+                "glob": "5.0.15",
+                "glob-parent": "3.1.0",
+                "micromatch": "2.3.11",
+                "ordered-read-streams": "0.3.0",
+                "through2": "0.6.5",
+                "to-absolute-glob": "0.1.1",
+                "unique-stream": "2.2.1"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "dev": true,
+                    "requires": {
+                        "inflight": "1.0.6",
+                        "inherits": "2.0.3",
+                        "minimatch": "3.0.4",
+                        "once": "1.4.0",
+                        "path-is-absolute": "1.0.1"
+                    }
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "0.6.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
+                    }
+                }
+            }
+        },
+        "glogg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+            "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+            "dev": true,
+            "requires": {
+                "sparkles": "1.0.0"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "growl": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+            "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+            "dev": true
+        },
+        "gulp-chmod": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/gulp-chmod/-/gulp-chmod-2.0.0.tgz",
+            "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
+            "dev": true,
+            "requires": {
+                "deep-assign": "1.0.0",
+                "stat-mode": "0.2.2",
+                "through2": "2.0.3"
+            }
+        },
+        "gulp-filter": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-5.1.0.tgz",
+            "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
+            "dev": true,
+            "requires": {
+                "multimatch": "2.1.0",
+                "plugin-error": "0.1.2",
+                "streamfilter": "1.0.7"
+            }
+        },
+        "gulp-gunzip": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/gulp-gunzip/-/gulp-gunzip-1.0.0.tgz",
+            "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
+            "dev": true,
+            "requires": {
+                "through2": "0.6.5",
+                "vinyl": "0.4.6"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                },
+                "through2": {
+                    "version": "0.6.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.0.34",
+                        "xtend": "4.0.1"
+                    }
+                }
+            }
+        },
+        "gulp-remote-src": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.3.tgz",
+            "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
+            "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "node.extend": "1.1.6",
+                "request": "2.79.0",
+                "through2": "2.0.3",
+                "vinyl": "2.0.2"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "request": {
+                    "version": "2.79.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+                    "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "0.6.0",
+                        "aws4": "1.6.0",
+                        "caseless": "0.11.0",
+                        "combined-stream": "1.0.6",
+                        "extend": "3.0.1",
+                        "forever-agent": "0.6.1",
+                        "form-data": "2.1.4",
+                        "har-validator": "2.0.6",
+                        "hawk": "3.1.3",
+                        "http-signature": "1.1.1",
+                        "is-typedarray": "1.0.0",
+                        "isstream": "0.1.2",
+                        "json-stringify-safe": "5.0.1",
+                        "mime-types": "2.1.18",
+                        "oauth-sign": "0.8.2",
+                        "qs": "6.3.2",
+                        "stringstream": "0.0.5",
+                        "tough-cookie": "2.3.3",
+                        "tunnel-agent": "0.4.3",
+                        "uuid": "3.2.1"
+                    }
+                },
+                "vinyl": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
+                    "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.3",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.0.0",
+                        "is-stream": "1.1.0",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
+                    }
+                }
+            }
+        },
+        "gulp-sourcemaps": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+            "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "1.1.3",
+                "graceful-fs": "4.1.11",
+                "strip-bom": "2.0.0",
+                "through2": "2.0.3",
+                "vinyl": "1.2.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.3",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
+                }
+            }
+        },
+        "gulp-symdest": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
+            "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
+            "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "mkdirp": "0.5.1",
+                "queue": "3.1.0",
+                "vinyl-fs": "2.4.4"
+            }
+        },
+        "gulp-untar": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
+            "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
+            "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "gulp-util": "3.0.8",
+                "streamifier": "0.1.1",
+                "tar": "2.2.1",
+                "through2": "2.0.3"
+            }
+        },
+        "gulp-util": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+            "dev": true,
+            "requires": {
+                "array-differ": "1.0.0",
+                "array-uniq": "1.0.3",
+                "beeper": "1.1.1",
+                "chalk": "1.1.3",
+                "dateformat": "2.2.0",
+                "fancy-log": "1.3.2",
+                "gulplog": "1.0.0",
+                "has-gulplog": "0.1.0",
+                "lodash._reescape": "3.0.0",
+                "lodash._reevaluate": "3.0.0",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.template": "3.6.2",
+                "minimist": "1.2.0",
+                "multipipe": "0.1.2",
+                "object-assign": "3.0.0",
+                "replace-ext": "0.0.1",
+                "through2": "2.0.3",
+                "vinyl": "0.5.3"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "0.5.3",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+                    "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.3",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
+                }
+            }
+        },
+        "gulp-vinyl-zip": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
+            "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
+            "dev": true,
+            "requires": {
+                "event-stream": "3.3.4",
+                "queue": "4.4.2",
+                "through2": "2.0.3",
+                "vinyl": "2.1.0",
+                "vinyl-fs": "2.4.4",
+                "yauzl": "2.9.1",
+                "yazl": "2.4.3"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "queue": {
+                    "version": "4.4.2",
+                    "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
+                    "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3"
+                    }
+                },
+                "vinyl": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
+                    "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "2.1.1",
+                        "clone-buffer": "1.0.0",
+                        "clone-stats": "1.0.0",
+                        "cloneable-readable": "1.0.0",
+                        "remove-trailing-separator": "1.1.0",
+                        "replace-ext": "1.0.0"
+                    }
+                }
+            }
+        },
+        "gulplog": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+            "dev": true,
+            "requires": {
+                "glogg": "1.0.1"
+            }
+        },
+        "har-schema": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
+        },
+        "har-validator": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+            "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "commander": "2.14.1",
+                "is-my-json-valid": "2.17.2",
+                "pinkie-promise": "2.0.1"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.14.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+                    "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw==",
+                    "dev": true
+                }
+            }
+        },
+        "has": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+            "dev": true,
+            "requires": {
+                "function-bind": "1.1.1"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "has-flag": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+            "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+            "dev": true
+        },
+        "has-gulplog": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+            "dev": true,
+            "requires": {
+                "sparkles": "1.0.0"
+            }
+        },
+        "hash-base": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+            "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
+        "hash.js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+            "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+            }
+        },
+        "hawk": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+            "dev": true,
+            "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+            }
+        },
+        "he": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "dev": true
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "dev": true,
+            "requires": {
+                "hash.js": "1.1.3",
+                "minimalistic-assert": "1.0.0",
+                "minimalistic-crypto-utils": "1.0.1"
+            }
+        },
+        "hoek": {
+            "version": "2.16.3",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+            "dev": true
+        },
+        "htmlescape": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+            "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
+            "dev": true
+        },
+        "http-signature": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.13.1"
+            }
+        },
+        "https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+            "dev": true
+        },
+        "ieee754": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+            "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+            "dev": true
+        },
+        "immutable": {
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+            "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+        },
+        "indexof": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "inline-source-map": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+            "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+            "dev": true,
+            "requires": {
+                "source-map": "0.5.7"
+            }
+        },
+        "insert-module-globals": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
+            "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.2",
+                "combine-source-map": "0.7.2",
+                "concat-stream": "1.5.2",
+                "is-buffer": "1.1.6",
+                "lexical-scope": "1.2.0",
+                "process": "0.11.10",
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+            },
+            "dependencies": {
+                "combine-source-map": {
+                    "version": "0.7.2",
+                    "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
+                    "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
+                    "dev": true,
+                    "requires": {
+                        "convert-source-map": "1.1.3",
+                        "inline-source-map": "0.6.2",
+                        "lodash.memoize": "3.0.4",
+                        "source-map": "0.5.7"
+                    }
+                }
+            }
+        },
+        "is": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+            "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "dev": true,
+            "requires": {
+                "is-primitive": "2.0.0"
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "2.1.1"
+            }
+        },
+        "is-my-ip-valid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+            "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+            "dev": true
+        },
+        "is-my-json-valid": {
+            "version": "2.17.2",
+            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+            "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+            "dev": true,
+            "requires": {
+                "generate-function": "2.0.0",
+                "generate-object-property": "1.2.0",
+                "is-my-ip-valid": "1.0.0",
+                "jsonpointer": "4.0.1",
+                "xtend": "4.0.1"
+            }
+        },
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "dev": true,
+            "requires": {
+                "kind-of": "3.2.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+            "dev": true
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "dev": true
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "dev": true
+        },
+        "is-property": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+            "dev": true
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-typedarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
+        },
+        "is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "is-valid-glob": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
+            "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "dev": true,
+            "requires": {
+                "isarray": "1.0.0"
+            }
+        },
+        "isstream": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+            "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+            "requires": {
+                "argparse": "1.0.10",
+                "esprima": "4.0.0"
+            }
+        },
+        "jsbn": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true,
+            "optional": true
+        },
+        "json-schema": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+            "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+            "dev": true,
+            "requires": {
+                "jsonify": "0.0.0"
+            }
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+            "dev": true
+        },
+        "jsonpointer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+            "dev": true
+        },
+        "jsprim": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.3.0",
+                "json-schema": "0.2.3",
+                "verror": "1.10.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "kind-of": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+            "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+            "dev": true
+        },
+        "labeled-stream-splicer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
+            "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "stream-splicer": "2.0.0"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                }
+            }
+        },
+        "lazystream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+            "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.4"
+            }
+        },
+        "lexical-scope": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+            "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
+            "dev": true,
+            "requires": {
+                "astw": "2.2.0"
+            }
+        },
+        "lodash._basecopy": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+            "dev": true
+        },
+        "lodash._basetostring": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+            "dev": true
+        },
+        "lodash._basevalues": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+            "dev": true
+        },
+        "lodash._getnative": {
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+            "dev": true
+        },
+        "lodash._isiterateecall": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+            "dev": true
+        },
+        "lodash._reescape": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+            "dev": true
+        },
+        "lodash._reevaluate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+            "dev": true
+        },
+        "lodash._reinterpolate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+            "dev": true
+        },
+        "lodash._root": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+            "dev": true
+        },
+        "lodash.escape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+            "dev": true,
+            "requires": {
+                "lodash._root": "3.0.1"
+            }
+        },
+        "lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+            "dev": true
+        },
+        "lodash.isarray": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+            "dev": true
+        },
+        "lodash.isequal": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+            "dev": true
+        },
+        "lodash.keys": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+            "dev": true,
+            "requires": {
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+            }
+        },
+        "lodash.memoize": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+            "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+            "dev": true
+        },
+        "lodash.restparam": {
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+            "dev": true
+        },
+        "lodash.template": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+            "dev": true,
+            "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash._basetostring": "3.0.1",
+                "lodash._basevalues": "3.0.0",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0",
+                "lodash.keys": "3.1.2",
+                "lodash.restparam": "3.6.1",
+                "lodash.templatesettings": "3.1.1"
+            }
+        },
+        "lodash.templatesettings": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+            "dev": true,
+            "requires": {
+                "lodash._reinterpolate": "3.0.0",
+                "lodash.escape": "3.2.0"
+            }
+        },
+        "map-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+            "dev": true
+        },
+        "md5.js": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+            "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+            "dev": true,
+            "requires": {
+                "hash-base": "3.0.4",
+                "inherits": "2.0.3"
+            },
+            "dependencies": {
+                "hash-base": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+                    "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.3",
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
+        "merge-stream": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.4"
+            }
+        },
+        "micromatch": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "dev": true,
+            "requires": {
+                "arr-diff": "2.0.0",
+                "array-unique": "0.2.1",
+                "braces": "1.8.5",
+                "expand-brackets": "0.1.5",
+                "extglob": "0.3.2",
+                "filename-regex": "2.0.1",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1",
+                "kind-of": "3.2.2",
+                "normalize-path": "2.1.1",
+                "object.omit": "2.0.1",
+                "parse-glob": "3.0.4",
+                "regex-cache": "0.4.4"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "1.1.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "brorand": "1.1.0"
+            }
+        },
+        "mime-db": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.18",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+            "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+            "dev": true,
+            "requires": {
+                "mime-db": "1.33.0"
+            }
+        },
+        "minimalistic-assert": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+            "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
+            "dev": true
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "1.1.11"
+            }
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
+            }
+        },
+        "mocha": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.0.1.tgz",
+            "integrity": "sha512-SpwyojlnE/WRBNGtvJSNfllfm5PqEDFxcWluSIgLeSBJtXG4DmoX2NNAeEA7rP5kK+79VgtVq8nG6HskaL1ykg==",
+            "dev": true,
+            "requires": {
+                "browser-stdout": "1.3.0",
+                "commander": "2.11.0",
+                "debug": "3.1.0",
+                "diff": "3.3.1",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.3",
+                "he": "1.1.1",
+                "mkdirp": "0.5.1",
+                "supports-color": "4.4.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                }
+            }
+        },
+        "module-deps": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+            "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "1.3.2",
+                "browser-resolve": "1.11.2",
+                "cached-path-relative": "1.0.1",
+                "concat-stream": "1.5.2",
+                "defined": "1.0.0",
+                "detective": "4.7.1",
+                "duplexer2": "0.1.4",
+                "inherits": "2.0.3",
+                "parents": "1.0.1",
+                "readable-stream": "2.3.4",
+                "resolve": "1.5.0",
+                "stream-combiner2": "1.1.1",
+                "subarg": "1.0.0",
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "multimatch": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+            "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+            "dev": true,
+            "requires": {
+                "array-differ": "1.0.0",
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "minimatch": "3.0.4"
+            }
+        },
+        "multipipe": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+            "dev": true,
+            "requires": {
+                "duplexer2": "0.0.2"
+            },
+            "dependencies": {
+                "duplexer2": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                    "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "1.1.14"
+                    }
+                },
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "1.1.14",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "0.0.1",
+                        "string_decoder": "0.10.31"
+                    }
+                },
+                "string_decoder": {
+                    "version": "0.10.31",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    "dev": true
+                }
+            }
+        },
+        "node.extend": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+            "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+            "dev": true,
+            "requires": {
+                "is": "3.2.1"
+            }
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true,
+            "requires": {
+                "remove-trailing-separator": "1.1.0"
+            }
+        },
+        "oauth-sign": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "dev": true,
+            "requires": {
+                "for-own": "0.1.5",
+                "is-extendable": "0.1.1"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "ordered-read-streams": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
+            "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+            "dev": true,
+            "requires": {
+                "is-stream": "1.1.0",
+                "readable-stream": "2.3.4"
+            }
+        },
+        "os-browserify": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+            "dev": true
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "pako": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+            "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
+            "dev": true
+        },
+        "parents": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+            "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+            "dev": true,
+            "requires": {
+                "path-platform": "0.11.15"
+            }
+        },
+        "parse-asn1": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+            "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+            "dev": true,
+            "requires": {
+                "asn1.js": "4.10.1",
+                "browserify-aes": "1.1.1",
+                "create-hash": "1.1.3",
+                "evp_bytestokey": "1.0.3",
+                "pbkdf2": "3.0.14"
+            }
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true,
+            "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.3",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "1.0.0"
+                    }
+                }
+            }
+        },
+        "path-browserify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+            "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+            "dev": true
+        },
+        "path-dirname": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+            "dev": true
+        },
+        "path-platform": {
+            "version": "0.11.15",
+            "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+            "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+            "dev": true
+        },
+        "pause-stream": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
+        },
+        "pbkdf2": {
+            "version": "3.0.14",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
+            "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+            "dev": true,
+            "requires": {
+                "create-hash": "1.1.3",
+                "create-hmac": "1.1.6",
+                "ripemd160": "2.0.1",
+                "safe-buffer": "5.1.1",
+                "sha.js": "2.4.10"
+            }
+        },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true
+        },
+        "performance-now": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "2.0.4"
+            }
+        },
+        "plugin-error": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+            "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+            "dev": true,
+            "requires": {
+                "ansi-cyan": "0.1.1",
+                "ansi-red": "0.1.1",
+                "arr-diff": "1.1.0",
+                "arr-union": "2.1.0",
+                "extend-shallow": "1.1.4"
+            }
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "dev": true
+        },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "dev": true
+        },
+        "public-encrypt": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+            "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+            "dev": true,
+            "requires": {
+                "bn.js": "4.11.8",
+                "browserify-rsa": "4.0.1",
+                "create-hash": "1.1.3",
+                "parse-asn1": "5.1.0",
+                "randombytes": "2.0.6"
+            }
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.3.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
+            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+            "dev": true
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
+        },
+        "querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+            "dev": true
+        },
+        "querystringify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz",
+            "integrity": "sha1-YoYkIRLFtxL6ZU5SZlK/ahP/Bcs=",
+            "dev": true
+        },
+        "queue": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
+            "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            }
+        },
+        "randomatic": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+            "dev": true,
+            "requires": {
+                "is-number": "3.0.0",
+                "kind-of": "4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "3.2.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "1.1.6"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "1.1.6"
+                    }
+                }
+            }
+        },
+        "randombytes": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
+            "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "2.0.6",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "read-only-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+            "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.4"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+            "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+            }
+        },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "dev": true,
+            "requires": {
+                "is-equal-shallow": "0.1.3"
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "repeat-element": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "replace-ext": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
+            "dev": true
+        },
+        "request": {
+            "version": "2.83.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+            "dev": true,
+            "requires": {
+                "aws-sign2": "0.7.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.6",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.3.2",
+                "har-validator": "5.0.3",
+                "hawk": "6.0.2",
+                "http-signature": "1.2.0",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.18",
+                "oauth-sign": "0.8.2",
+                "performance-now": "2.1.0",
+                "qs": "6.5.1",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.3",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.2.1"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                },
+                "aws-sign2": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+                    "dev": true
+                },
+                "boom": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+                    "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.1"
+                    }
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+                    "dev": true
+                },
+                "cryptiles": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+                    "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+                    "dev": true,
+                    "requires": {
+                        "boom": "5.2.0"
+                    },
+                    "dependencies": {
+                        "boom": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+                            "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+                            "dev": true,
+                            "requires": {
+                                "hoek": "4.2.1"
+                            }
+                        }
+                    }
+                },
+                "form-data": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+                    "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "0.4.0",
+                        "combined-stream": "1.0.6",
+                        "mime-types": "2.1.18"
+                    }
+                },
+                "har-validator": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "5.5.2",
+                        "har-schema": "2.0.0"
+                    }
+                },
+                "hawk": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+                    "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+                    "dev": true,
+                    "requires": {
+                        "boom": "4.3.1",
+                        "cryptiles": "3.1.2",
+                        "hoek": "4.2.1",
+                        "sntp": "2.1.0"
+                    }
+                },
+                "hoek": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+                    "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+                    "dev": true,
+                    "requires": {
+                        "assert-plus": "1.0.0",
+                        "jsprim": "1.4.1",
+                        "sshpk": "1.13.1"
+                    }
+                },
+                "qs": {
+                    "version": "6.5.1",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+                    "dev": true
+                },
+                "sntp": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+                    "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "4.2.1"
+                    }
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "5.1.1"
+                    }
+                }
+            }
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+            "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+            "dev": true,
+            "requires": {
+                "path-parse": "1.0.5"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            }
+        },
+        "ripemd160": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+            "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+            "dev": true,
+            "requires": {
+                "hash-base": "2.0.2",
+                "inherits": "2.0.3"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+            "dev": true
+        },
+        "sha.js": {
+            "version": "2.4.10",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
+            "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "shasum": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+            "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify": "0.0.1",
+                "sha.js": "2.4.10"
+            }
+        },
+        "shell-quote": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+            "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+            "dev": true,
+            "requires": {
+                "array-filter": "0.0.1",
+                "array-map": "0.0.0",
+                "array-reduce": "0.0.0",
+                "jsonify": "0.0.0"
+            }
+        },
+        "sntp": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+            "dev": true,
+            "requires": {
+                "hoek": "2.16.3"
+            }
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+            "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+            "dev": true,
+            "requires": {
+                "source-map": "0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "sparkles": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+            "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+            "dev": true
+        },
+        "split": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+            "dev": true,
+            "requires": {
+                "through": "2.3.8"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        },
+        "sshpk": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "dev": true,
+            "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "stat-mode": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+            "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI=",
+            "dev": true
+        },
+        "stream-browserify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+            "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4"
+            }
+        },
+        "stream-combiner": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+            "dev": true,
+            "requires": {
+                "duplexer": "0.1.1"
+            }
+        },
+        "stream-combiner2": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+            "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+            "dev": true,
+            "requires": {
+                "duplexer2": "0.1.4",
+                "readable-stream": "2.3.4"
+            }
+        },
+        "stream-http": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
+            "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
+            "dev": true,
+            "requires": {
+                "builtin-status-codes": "3.0.0",
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4",
+                "to-arraybuffer": "1.0.1",
+                "xtend": "4.0.1"
+            }
+        },
+        "stream-shift": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+            "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+            "dev": true
+        },
+        "stream-splicer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+            "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.4"
+            }
+        },
+        "streamfilter": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/streamfilter/-/streamfilter-1.0.7.tgz",
+            "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.4"
+            }
+        },
+        "streamifier": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/streamifier/-/streamifier-0.1.1.tgz",
+            "integrity": "sha1-l+mNj6TRBdYqJpHR3AfoINuN/E8=",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "stringstream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "strip-bom": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true,
+            "requires": {
+                "is-utf8": "0.2.1"
+            }
+        },
+        "strip-bom-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
+            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
+            "dev": true,
+            "requires": {
+                "first-chunk-stream": "1.0.0",
+                "strip-bom": "2.0.0"
+            }
+        },
+        "subarg": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+            "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+            "dev": true,
+            "requires": {
+                "minimist": "1.2.0"
+            }
+        },
+        "supports-color": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+            "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+            "dev": true,
+            "requires": {
+                "has-flag": "2.0.0"
+            }
+        },
+        "syntax-error": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+            "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "1.3.0"
+            }
+        },
+        "tar": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+            "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+            "dev": true,
+            "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+            }
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "through2": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "2.3.4",
+                "xtend": "4.0.1"
+            }
+        },
+        "through2-filter": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
+            "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+            "dev": true,
+            "requires": {
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+            }
+        },
+        "time-stamp": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+            "dev": true
+        },
+        "timers-browserify": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+            "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+            "dev": true,
+            "requires": {
+                "process": "0.11.10"
+            }
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "to-absolute-glob": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
+            "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "2.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "0.1.1"
+                    }
+                }
+            }
+        },
+        "to-arraybuffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+            "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+            "dev": true
+        },
+        "tough-cookie": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+            "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.4.1"
+            }
+        },
+        "tty-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+            "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+            "dev": true
+        },
+        "tunnel-agent": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
+            "dev": true
+        },
+        "tweetnacl": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true,
+            "optional": true
+        },
+        "type-detect": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+            "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+            "dev": true
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "typescript": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+            "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
+            "dev": true
+        },
+        "umd": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+            "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
+            "dev": true
+        },
+        "unique-stream": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
+            "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify": "1.0.1",
+                "through2-filter": "2.0.0"
+            },
+            "dependencies": {
+                "json-stable-stringify": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                    "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+                    "dev": true,
+                    "requires": {
+                        "jsonify": "0.0.0"
+                    }
+                }
+            }
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                }
+            }
+        },
+        "url-parse": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
+            "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
+            "dev": true,
+            "requires": {
+                "querystringify": "1.0.0",
+                "requires-port": "1.0.0"
+            }
+        },
+        "util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+            "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.1"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                    "dev": true
+                }
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+            "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+            "dev": true
+        },
+        "vali-date": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
+            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+            "dev": true
+        },
+        "verror": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
+            "requires": {
+                "assert-plus": "1.0.0",
+                "core-util-is": "1.0.2",
+                "extsprintf": "1.3.0"
+            },
+            "dependencies": {
+                "assert-plus": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                    "dev": true
+                }
+            }
+        },
+        "vinyl": {
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+            "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+            "dev": true,
+            "requires": {
+                "clone": "0.2.0",
+                "clone-stats": "0.0.1"
+            }
+        },
+        "vinyl-fs": {
+            "version": "2.4.4",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
+            "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+            "dev": true,
+            "requires": {
+                "duplexify": "3.5.3",
+                "glob-stream": "5.3.5",
+                "graceful-fs": "4.1.11",
+                "gulp-sourcemaps": "1.6.0",
+                "is-valid-glob": "0.3.0",
+                "lazystream": "1.0.0",
+                "lodash.isequal": "4.5.0",
+                "merge-stream": "1.0.1",
+                "mkdirp": "0.5.1",
+                "object-assign": "4.1.1",
+                "readable-stream": "2.3.4",
+                "strip-bom": "2.0.0",
+                "strip-bom-stream": "1.0.0",
+                "through2": "2.0.3",
+                "through2-filter": "2.0.0",
+                "vali-date": "1.0.0",
+                "vinyl": "1.2.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+                    "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+                    "dev": true
+                },
+                "replace-ext": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "dev": true,
+                    "requires": {
+                        "clone": "1.0.3",
+                        "clone-stats": "0.0.1",
+                        "replace-ext": "0.0.1"
+                    }
+                }
+            }
+        },
+        "vinyl-source-stream": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vinyl-source-stream/-/vinyl-source-stream-1.1.2.tgz",
+            "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
+            "dev": true,
+            "requires": {
+                "through2": "2.0.3",
+                "vinyl": "0.4.6"
+            }
+        },
+        "vm-browserify": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+            "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+            "dev": true,
+            "requires": {
+                "indexof": "0.0.1"
+            }
+        },
+        "vscode": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.10.tgz",
+            "integrity": "sha512-MvFXXSGuhw0Q6GC6dQrnRc0ES+63wpttGIoYGBMQnoS9JFCCNC/rWfX0lBCHJyuKL2Q8CYg0ROsMEHbHVwEtVw==",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2",
+                "gulp-chmod": "2.0.0",
+                "gulp-filter": "5.1.0",
+                "gulp-gunzip": "1.0.0",
+                "gulp-remote-src": "0.4.3",
+                "gulp-symdest": "1.1.0",
+                "gulp-untar": "0.0.6",
+                "gulp-vinyl-zip": "2.1.0",
+                "mocha": "4.1.0",
+                "request": "2.83.0",
+                "semver": "5.5.0",
+                "source-map-support": "0.5.3",
+                "url-parse": "1.2.0",
+                "vinyl-source-stream": "1.1.2"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.11.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+                    "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "diff": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+                    "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+                    "dev": true
+                },
+                "escape-string-regexp": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                    "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                    "dev": true
+                },
+                "growl": {
+                    "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+                    "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+                    "dev": true
+                },
+                "mocha": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+                    "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
+                    "dev": true,
+                    "requires": {
+                        "browser-stdout": "1.3.0",
+                        "commander": "2.11.0",
+                        "debug": "3.1.0",
+                        "diff": "3.3.1",
+                        "escape-string-regexp": "1.0.5",
+                        "glob": "7.1.2",
+                        "growl": "1.10.3",
+                        "he": "1.1.1",
+                        "mkdirp": "0.5.1",
+                        "supports-color": "4.4.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+                    "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "2.0.0"
+                    }
+                }
+            }
+        },
+        "vscode-jsonrpc": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
+            "integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o="
+        },
+        "vscode-languageclient": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-3.5.0.tgz",
+            "integrity": "sha1-NtAswYaoNlpEZ3GaKQ+yAKmuSQo=",
+            "requires": {
+                "vscode-languageserver-protocol": "3.5.0"
+            }
+        },
+        "vscode-languageserver": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-3.5.0.tgz",
+            "integrity": "sha1-0oCZvG3dqMHdFrcH5FThsd2uDbo=",
+            "requires": {
+                "vscode-languageserver-protocol": "3.5.0",
+                "vscode-uri": "1.0.1"
+            }
+        },
+        "vscode-languageserver-protocol": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.5.0.tgz",
+            "integrity": "sha1-Bnxcvidwl5U5jRGWksl+u6FFIgk=",
+            "requires": {
+                "vscode-jsonrpc": "3.5.0",
+                "vscode-languageserver-types": "3.5.0"
+            }
+        },
+        "vscode-languageserver-types": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.5.0.tgz",
+            "integrity": "sha1-5I15li8LjgLelV4/UkkI4rGcA3Q="
+        },
+        "vscode-uri": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
+            "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        },
+        "yauzl": {
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+            "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "0.2.13",
+                "fd-slicer": "1.0.1"
+            }
+        },
+        "yazl": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
+            "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "0.2.13"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,119 +1,121 @@
 {
-   "activationEvents": [
-      "onLanguage:jsonnet",
-      "onCommand:jsonnet.previewToSide",
-      "onCommand:jsonnet.preview"
-   ],
-   "categories": [
-      "Languages"
-   ],
-   "contributes": {
-      "commands": [
-         {
-            "command": "jsonnet.previewToSide",
-            "title": "Jsonnet: Open Preview to the Side"
-         },
-         {
-            "command": "jsonnet.preview",
-            "title": "Jsonnet: Open Preview"
-         }
-      ],
-      "configuration": {
-         "properties": {
-            "jsonnet.executablePath": {
-               "default": null,
-               "description": "Location of the `jsonnet` executable.",
-               "type": "string"
+    "activationEvents": [
+        "onLanguage:jsonnet",
+        "onCommand:jsonnet.previewToSide",
+        "onCommand:jsonnet.preview"
+    ],
+    "categories": [
+        "Languages"
+    ],
+    "contributes": {
+        "commands": [
+            {
+                "command": "jsonnet.previewToSide",
+                "title": "Jsonnet: Open Preview to the Side"
             },
-            "jsonnet.extStrs": {
-               "default": null,
-               "description": "External strings to pass to `jsonnet` executable.",
-               "type": "object"
-            },
-            "jsonnet.libPaths": {
-               "default": [ ],
-               "description": "Additional paths to search for libraries when compiling Jsonnet code.",
-               "type": "array"
-            },
-            "jsonnet.outputFormat": {
-               "default": "yaml",
-               "description": "Preview output format (yaml / json)",
-               "enum": [
-                  "json",
-                  "yaml"
-               ]
+            {
+                "command": "jsonnet.preview",
+                "title": "Jsonnet: Open Preview"
             }
-         },
-         "title": "Jsonnet configuration",
-         "type": "object"
-      },
-      "grammars": [
-         {
-            "language": "jsonnet",
-            "path": "./syntaxes/jsonnet.tmLanguage.json",
-            "scopeName": "source.jsonnet"
-         }
-      ],
-      "keybindings": [
-         {
-            "command": "jsonnet.previewToSide",
-            "key": "shift+ctrl+i",
-            "mac": "shift+cmd+i",
-            "when": "editorFocus"
-         }
-      ],
-      "languages": [
-         {
-            "aliases": [
-               "Jsonnet",
-               "jsonnet"
-            ],
-            "configuration": "./language-configuration.json",
-            "extensions": [
-               ".jsonnet",
-               ".libsonnet"
-            ],
-            "id": "jsonnet"
-         }
-      ]
-   },
-   "dependencies": {
-      "immutable": "^3.8.1",
-      "js-yaml": "^3.0.0",
-      "vscode-languageclient": "^3.1.0",
-      "vscode-languageserver": "^3.1.0"
-   },
-   "description": "Language support for Jsonnet",
-   "devDependencies": {
-      "@types/chai": "^3.5.0",
-      "@types/mocha": "^2.2.32",
-      "@types/node": "^6.0.40",
-      "browserify": "^14.3.0",
-      "chai": "^3.5.0",
-      "mocha": "^2.3.3",
-      "typescript": "^2.3.2",
-      "vscode": "^1.0.0"
-   },
-   "displayName": "Jsonnet",
-   "engines": {
-      "vscode": "^1.10.0"
-   },
-   "homepage": "https://github.com/heptio/vscode-jsonnet/blob/master/README.md",
-   "license": "SEE LICENSE IN 'LICENSE' file",
-   "main": "./out/client/extension",
-   "name": "jsonnet",
-   "publisher": "heptio",
-   "repository": {
-      "type": "git",
-      "url": "https://github.com/heptio/vscode-jsonnet.git"
-   },
-   "scripts": {
-      "compile": "tsc -watch -p ./",
-      "compile-once": "tsc -p ./",
-      "compile-site": "browserify ./out/site/main.js > ksonnet.js",
-      "postinstall": "node ./node_modules/vscode/bin/install",
-      "test": "node ./node_modules/vscode/bin/test",
-      "vscode:prepublish": "tsc -p ./"
-   },
-   "version": "0.0.15"
+        ],
+        "configuration": {
+            "properties": {
+                "jsonnet.executablePath": {
+                    "default": null,
+                    "description": "Location of the `jsonnet` executable.",
+                    "type": "string"
+                },
+                "jsonnet.extStrs": {
+                    "default": null,
+                    "description": "External strings to pass to `jsonnet` executable.",
+                    "type": "object"
+                },
+                "jsonnet.libPaths": {
+                    "default": [],
+                    "description": "Additional paths to search for libraries when compiling Jsonnet code.",
+                    "type": "array"
+                },
+                "jsonnet.outputFormat": {
+                    "default": "yaml",
+                    "description": "Preview output format (yaml / json)",
+                    "enum": [
+                        "json",
+                        "yaml"
+                    ]
+                }
+            },
+            "title": "Jsonnet configuration",
+            "type": "object"
+        },
+        "grammars": [
+            {
+                "language": "jsonnet",
+                "path": "./syntaxes/jsonnet.tmLanguage.json",
+                "scopeName": "source.jsonnet"
+            }
+        ],
+        "keybindings": [
+            {
+                "command": "jsonnet.previewToSide",
+                "key": "shift+ctrl+i",
+                "mac": "shift+cmd+i",
+                "when": "editorFocus"
+            }
+        ],
+        "languages": [
+            {
+                "aliases": [
+                    "Jsonnet",
+                    "jsonnet"
+                ],
+                "configuration": "./language-configuration.json",
+                "extensions": [
+                    ".jsonnet",
+                    ".libsonnet"
+                ],
+                "id": "jsonnet"
+            }
+        ]
+    },
+    "dependencies": {
+        "filepath": "^1.1.0",
+        "immutable": "^3.8.1",
+        "js-yaml": "^3.0.0",
+        "tmp": "0.0.33",
+        "vscode-languageclient": "^3.1.0",
+        "vscode-languageserver": "^3.1.0"
+    },
+    "description": "Language support for Jsonnet",
+    "devDependencies": {
+        "@types/chai": "^3.5.0",
+        "@types/mocha": "^2.2.42",
+        "@types/node": "^6.0.40",
+        "browserify": "^14.3.0",
+        "chai": "^3.5.0",
+        "mocha": "^5.0.1",
+        "typescript": "^2.3.2",
+        "vscode": "^1.0.0"
+    },
+    "displayName": "Jsonnet",
+    "engines": {
+        "vscode": "^1.18.x"
+    },
+    "homepage": "https://github.com/heptio/vscode-jsonnet/blob/master/README.md",
+    "license": "SEE LICENSE IN 'LICENSE' file",
+    "main": "./out/client/extension",
+    "name": "jsonnet",
+    "publisher": "heptio",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/heptio/vscode-jsonnet.git"
+    },
+    "scripts": {
+        "compile": "tsc -watch -p ./",
+        "compile-once": "tsc -p ./",
+        "compile-site": "browserify ./out/site/main.js > ksonnet.js",
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "test": "node ./node_modules/vscode/bin/test",
+        "vscode:prepublish": "tsc -p ./"
+    },
+    "version": "0.0.15"
 }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,0 +1,91 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import * as tmp from 'tmp';
+import * as myExt from '../client/extension';
+
+describe("extension tests", () => {
+    describe("ksonnet", () => {
+        const dirs = ["/foo/components/ns"];
+        const files = ["/foo/app.yaml"];
+
+        describe("isInApp", () => {
+
+            function withTemp(curPath: string, expected: any) {
+                tmp.dir((err, rootPath, cleanupCallback) => {
+                    for (let d in dirs) {
+                        const dirPath = path.join(rootPath, d);
+                        fs.mkdirSync(dirPath);
+                    }
+
+                    for (let f in files) {
+                        const filePath = path.join(rootPath, f);
+                        fs.writeFileSync(filePath, '');
+                    }
+
+                    const cur = path.join(rootPath, curPath);
+                    const got = myExt.ksonnet.isInApp(cur);
+                    assert.equal(got, expected);
+
+                    cleanupCallback();
+                })
+            }
+
+            it("with a file in components is in a ksonnet app", () => {
+                withTemp('/foo/components/file.jsonnet', true);
+            })
+
+            it("with a file in a component namespace is in a ksonnet app", () => {
+                withTemp('/foo/components/ns/file.jsonnet', true);
+            })
+
+            it("with a file not under the components hierarchy is not in a ksonnet app", () => {
+                withTemp('/foo/ns/file.jsonnet', false);
+            })
+
+            it("with a file in the root directory is not a ksonnet app", () => {
+                withTemp('/', false);
+            })
+        })
+
+        describe('rootPath', () => {
+
+            function withTemp(curPath: string, expected: any) {
+                tmp.dir((err, rootPath, cleanupCallback) => {
+                    for (let d in dirs) {
+                        const dirPath = path.join(rootPath, d);
+                        fs.mkdirSync(dirPath);
+                    }
+
+                    for (let f in files) {
+                        const filePath = path.join(rootPath, f);
+                        fs.writeFileSync(filePath, '');
+                    }
+
+                    const cur = path.join(rootPath, curPath);
+                    const got = myExt.ksonnet.rootPath(cur);
+                    assert.equal(got, expected);
+
+                    cleanupCallback();
+                })
+            }
+
+            it("with a file in components is in a ksonnet app", () => {
+                withTemp('/foo/components/file.jsonnet', '/foo');
+            })
+
+            it("with a file in a component namespace is in a ksonnet app", () => {
+                withTemp('/foo/components/ns/file.jsonnet', '/foo');
+            })
+
+            it("with a file not under the components hierarchy is not in a ksonnet app", () => {
+                withTemp('/foo/ns/file.jsonnet', '');
+            })
+
+            it("with a file in the root directory is not a ksonnet app", () => {
+                withTemp('/', '');
+            })
+        })
+    })
+})

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,22 @@
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+import * as testRunner from 'vscode/lib/testrunner';
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+testRunner.configure({
+    ui: 'bdd',          // the TDD UI is being used in extension.test.ts (suite, test, etc.)
+    useColors: true // colored output from test results
+});
+
+module.exports = testRunner;


### PR DESCRIPTION
This change allows the extension to have knowledge on how to render ksonnet components. It provides two `ext-code` parameters when running jsonnet:

* `__ksonnet/environments`
* `__ksonnet/params`

These will only be made available for jsonnet source which resides under a ksonnet `components` directory.

It also adds a `package-lock.json` file for tracking npm versions in a more repeatable way.